### PR TITLE
Updating getFaces with { raw } option

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build:site": "vite build --config site/vite.config.js",
     "preview": "vite preview site",
     "test": "npm run bench",
-    "bench": "node tests/getFaces.bench.js",
+    "bench": "node tests/benches.js",
     "format": "prettier --write \"src/**/*.js\" \"site/**/*.js\" \"site/**/*.css\" \"site/**/*.html\"",
     "format:check": "prettier --check \"src/**/*.js\" \"site/**/*.js\" \"site/**/*.css\" \"site/**/*.html\""
   },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "build": "vite build && tsc",
     "build:site": "vite build --config site/vite.config.js",
     "preview": "vite preview site",
+    "test": "npm run bench",
+    "bench": "node tests/getFaces.bench.js",
     "format": "prettier --write \"src/**/*.js\" \"site/**/*.js\" \"site/**/*.css\" \"site/**/*.html\"",
     "format:check": "prettier --check \"src/**/*.js\" \"site/**/*.js\" \"site/**/*.css\" \"site/**/*.html\""
   },

--- a/src/heerich.js
+++ b/src/heerich.js
@@ -4,6 +4,8 @@ import { Points } from "./points.js";
 import { boxCoords, sphereCoords, lineCoords, fillCoords } from "./shapes.js";
 
 export { boxCoords, sphereCoords, lineCoords, fillCoords };
+export { GPURenderer } from "./gpu-renderer.js";
+export { SVGRenderer } from "./svg-renderer.js";
 
 /**
  * @typedef {Object} StyleObject
@@ -165,16 +167,18 @@ export class Heerich {
     this._cachedEpoch = -1;
     /** @type {Face[]|null} */
     this._cachedFaces = null;
+    /** @type {number} Epoch at which _cachedRawFaces was computed */
+    this._cachedRawEpoch = -1;
+    /** @type {Face[]|null} */
+    this._cachedRawFaces = null;
     /** @type {SVGRenderer|null} */
     this._svgRenderer = null;
     /** @type {boolean} */
     this._batching = false;
-    /** @type {Set<number>} Voxel keys that changed since last getFaces */
+    /** @type {Set<number>} Voxel keys that changed since last _buildFaces3D */
     this._dirtyKeys = new Set();
     /** @type {Map<number, Object[]>} Cached 3D faces per voxel key */
     this._faceCache3D = new Map();
-    /** @type {number} Epoch at which the full cache was last valid */
-    this._faceCacheEpoch = -1;
   }
 
   /**
@@ -231,7 +235,10 @@ export class Heerich {
   /** Mark the scene as modified. */
   _invalidate() {
     this._epoch++;
-    if (!this._batching) this._cachedFaces = null;
+    if (!this._batching) {
+      this._cachedFaces = null;
+      this._cachedRawFaces = null;
+    }
   }
 
   /**
@@ -845,41 +852,25 @@ export class Heerich {
   }
 
   /**
-   * Generate an array of renderable 2D polygon faces from stored voxels, properly depth-sorted.
-   * Results are cached until the scene is modified.
-   * @returns {Face[]}
+   * Build all neighbor-exposed 3D faces for every voxel, using the incremental
+   * per-voxel cache. Always emits all 6 faces (camera direction is irrelevant
+   * here — filtering happens in `_projectAndSort` for SVG, or in the GPU
+   * renderer's own backface culling for 3D output).
+   *
+   * Each face carries `n` (normal) and `c` (center) so that `_projectAndSort`
+   * can do backface culling and depth computation without extra lookups.
+   *
+   * @returns {Object[]} Raw 3D face objects
    */
-  getFaces() {
-    if (this._cachedEpoch === this._epoch && this._cachedFaces) {
-      return this._cachedFaces;
-    }
-
-    const projectedFaces = [];
-    const {
-      projection,
-      tileW,
-      tileH,
-      depthOffsetX,
-      depthOffsetY,
-      cameraX,
-      cameraY,
-      cameraDistance,
-    } = this.renderOptions;
-
+  _buildFaces3D() {
     const hasVoxel = (x, y, z) => {
       const v = this.voxels.get(this._k(x, y, z));
       return v && v.opaque !== false;
     };
 
-    // Oblique depth constants (used in face gen and content projection)
-    const dx_norm = projection === "oblique" ? depthOffsetX / tileW : 0;
-    const dy_norm = projection === "oblique" ? depthOffsetY / tileH : 0;
-
-    // Incremental: only regenerate 3D faces for dirty voxels
     const dirtyKeys = this._dirtyKeys;
     const useIncremental = dirtyKeys.size > 0 && this._faceCache3D.size > 0;
 
-    // Remove cache entries for deleted voxels
     if (useIncremental) {
       for (const dk of dirtyKeys) {
         this._faceCache3D.delete(dk);
@@ -887,8 +878,8 @@ export class Heerich {
     }
 
     const faces3D = [];
+
     for (const [key, voxel] of this.voxels.entries()) {
-      // Reuse cached 3D faces for unchanged voxels
       if (useIncremental && !dirtyKeys.has(key)) {
         const cached = this._faceCache3D.get(key);
         if (cached) {
@@ -899,7 +890,6 @@ export class Heerich {
 
       const { x, y, z, styles } = voxel;
 
-      // Skip fully occluded voxels — all 6 neighbors are opaque
       if (
         !voxel.scale &&
         hasVoxel(x - 1, y, z) &&
@@ -914,231 +904,96 @@ export class Heerich {
 
       const faceStart = faces3D.length;
 
-      // Content voxels: emit a content entry instead of polygon faces
       if (voxel.content) {
-        faces3D.push({
-          type: "content",
-          voxel,
-          content: voxel.content,
-          _pos: [x, y, z],
-        });
+        faces3D.push({ type: "content", voxel, content: voxel.content, _pos: [x, y, z] });
         this._faceCache3D.set(key, faces3D.slice(faceStart));
         continue;
       }
 
-      // Precompute base style (default + styles.default) once per voxel
       const base = styles.default
         ? { ...this.defaultStyle, ...styles.default }
         : this.defaultStyle;
-      const getStyles = (faceName) => {
+      const getStyle = (faceName) => {
         const faceStyle = styles[faceName];
         return faceStyle ? { ...base, ...faceStyle } : base;
       };
 
-      // In Oblique projection:
-      // A standard grid relies on absolute occlusion to decide boundaries.
-      // If we just mapped raw vectors, parallel walls get confused by the math.
-      // We fall back conditionally to explicit voxel checking for oblique, but true vector calculation for perspective.
-
       const sc = voxel.scale;
       const so = voxel.scaleOrigin;
 
-      if (projection === "oblique") {
-        const getDepth = (cx, cy, cz) => cz - cx * dx_norm - cy * dy_norm;
+      const addFace = (type, vertices, n, cx, cy, cz) => {
+        let c = [cx, cy, cz];
+        if (sc) {
+          const ox = x + so[0], oy = y + so[1], oz = z + so[2];
+          c = [
+            ox + (cx - ox) * sc[0],
+            oy + (cy - oy) * sc[1],
+            oz + (cz - oz) * sc[2],
+          ];
+        }
+        faces3D.push({
+          type,
+          voxel,
+          vertices: sc ? Heerich._scaleVertices(vertices, x, y, z, sc, so) : vertices,
+          n,
+          c,
+          style: getStyle(type),
+        });
+      };
 
-        const addObliqueFace = (type, vertices, cx, cy, cz) => {
-          faces3D.push({
-            type,
-            voxel,
-            vertices: sc
-              ? Heerich._scaleVertices(vertices, x, y, z, sc, so)
-              : vertices,
-            depth: getDepth(cx, cy, cz),
-            style: getStyles(type),
-          });
-        };
+      // Emit all 6 neighbor-exposed faces. Camera-direction filtering is
+      // deferred to _projectAndSort (for SVG) or left to the GPU.
+      if (sc || !hasVoxel(x, y - 1, z))
+        addFace("top",    [[x,y,z],[x+1,y,z],[x+1,y,z+1],[x,y,z+1]],             [0,-1,0], x+0.5, y,   z+0.5);
+      if (sc || !hasVoxel(x, y + 1, z))
+        addFace("bottom", [[x,y+1,z+1],[x+1,y+1,z+1],[x+1,y+1,z],[x,y+1,z]],   [0,1,0],  x+0.5, y+1, z+0.5);
+      if (sc || !hasVoxel(x - 1, y, z))
+        addFace("left",   [[x,y,z+1],[x,y,z],[x,y+1,z],[x,y+1,z+1]],             [-1,0,0], x,   y+0.5, z+0.5);
+      if (sc || !hasVoxel(x + 1, y, z))
+        addFace("right",  [[x+1,y,z],[x+1,y,z+1],[x+1,y+1,z+1],[x+1,y+1,z]],   [1,0,0],  x+1, y+0.5, z+0.5);
+      if (sc || !hasVoxel(x, y, z - 1))
+        addFace("front",  [[x,y,z],[x,y+1,z],[x+1,y+1,z],[x+1,y,z]],             [0,0,-1], x+0.5, y+0.5, z);
+      if (sc || !hasVoxel(x, y, z + 1))
+        addFace("back",   [[x+1,y,z+1],[x+1,y+1,z+1],[x,y+1,z+1],[x,y,z+1]],   [0,0,1],  x+0.5, y+0.5, z+1);
 
-        // For oblique, we strictly cull invisible orientations
-        // Scaled voxels bypass neighbor occlusion (they don't fill the cell)
-        if (depthOffsetY < 0 && (sc || !hasVoxel(x, y - 1, z)))
-          addObliqueFace(
-            "top",
-            [
-              [x, y, z],
-              [x + 1, y, z],
-              [x + 1, y, z + 1],
-              [x, y, z + 1],
-            ],
-            x + 0.5,
-            y,
-            z + 0.5,
-          );
-        if (depthOffsetY > 0 && (sc || !hasVoxel(x, y + 1, z)))
-          addObliqueFace(
-            "bottom",
-            [
-              [x, y + 1, z + 1],
-              [x + 1, y + 1, z + 1],
-              [x + 1, y + 1, z],
-              [x, y + 1, z],
-            ],
-            x + 0.5,
-            y + 1,
-            z + 0.5,
-          );
-
-        if (depthOffsetX < 0 && (sc || !hasVoxel(x - 1, y, z)))
-          addObliqueFace(
-            "left",
-            [
-              [x, y, z + 1],
-              [x, y, z],
-              [x, y + 1, z],
-              [x, y + 1, z + 1],
-            ],
-            x,
-            y + 0.5,
-            z + 0.5,
-          );
-        if (depthOffsetX > 0 && (sc || !hasVoxel(x + 1, y, z)))
-          addObliqueFace(
-            "right",
-            [
-              [x + 1, y, z],
-              [x + 1, y, z + 1],
-              [x + 1, y + 1, z + 1],
-              [x + 1, y + 1, z],
-            ],
-            x + 1,
-            y + 0.5,
-            z + 0.5,
-          );
-
-        // Oblique depth always increases with z so the camera looks from
-        // –z.  "front" (normal –z) faces the camera; "back" (normal +z)
-        // always faces away — never visible, skip it.
-        if (sc || !hasVoxel(x, y, z - 1))
-          addObliqueFace(
-            "front",
-            [
-              [x, y, z],
-              [x, y + 1, z],
-              [x + 1, y + 1, z],
-              [x + 1, y, z],
-            ],
-            x + 0.5,
-            y + 0.5,
-            z,
-          );
-      } else {
-        // Perspective Mode uses robust 3D math and backface culling
-        const addPerspFace = (type, vertices, n, c) => {
-          if (sc) {
-            const ox = x + so[0],
-              oy = y + so[1],
-              oz = z + so[2];
-            c = [
-              ox + (c[0] - ox) * sc[0],
-              oy + (c[1] - oy) * sc[1],
-              oz + (c[2] - oz) * sc[2],
-            ];
-          }
-          faces3D.push({
-            type,
-            voxel,
-            vertices: sc
-              ? Heerich._scaleVertices(vertices, x, y, z, sc, so)
-              : vertices,
-            n,
-            c,
-            style: getStyles(type),
-          });
-        };
-
-        if (sc || !hasVoxel(x, y - 1, z))
-          addPerspFace(
-            "top",
-            [
-              [x, y, z],
-              [x + 1, y, z],
-              [x + 1, y, z + 1],
-              [x, y, z + 1],
-            ],
-            [0, -1, 0],
-            [x + 0.5, y, z + 0.5],
-          );
-        if (sc || !hasVoxel(x, y + 1, z))
-          addPerspFace(
-            "bottom",
-            [
-              [x, y + 1, z + 1],
-              [x + 1, y + 1, z + 1],
-              [x + 1, y + 1, z],
-              [x, y + 1, z],
-            ],
-            [0, 1, 0],
-            [x + 0.5, y + 1, z + 0.5],
-          );
-        if (sc || !hasVoxel(x - 1, y, z))
-          addPerspFace(
-            "left",
-            [
-              [x, y, z + 1],
-              [x, y, z],
-              [x, y + 1, z],
-              [x, y + 1, z + 1],
-            ],
-            [-1, 0, 0],
-            [x, y + 0.5, z + 0.5],
-          );
-        if (sc || !hasVoxel(x + 1, y, z))
-          addPerspFace(
-            "right",
-            [
-              [x + 1, y, z],
-              [x + 1, y, z + 1],
-              [x + 1, y + 1, z + 1],
-              [x + 1, y + 1, z],
-            ],
-            [1, 0, 0],
-            [x + 1, y + 0.5, z + 0.5],
-          );
-        if (sc || !hasVoxel(x, y, z - 1))
-          addPerspFace(
-            "front",
-            [
-              [x, y, z],
-              [x, y + 1, z],
-              [x + 1, y + 1, z],
-              [x + 1, y, z],
-            ],
-            [0, 0, -1],
-            [x + 0.5, y + 0.5, z],
-          );
-        if (sc || !hasVoxel(x, y, z + 1))
-          addPerspFace(
-            "back",
-            [
-              [x + 1, y, z + 1],
-              [x + 1, y + 1, z + 1],
-              [x, y + 1, z + 1],
-              [x, y, z + 1],
-            ],
-            [0, 0, 1],
-            [x + 0.5, y + 0.5, z + 1],
-          );
-      }
-
-      // Cache this voxel's 3D faces for incremental updates
       if (faces3D.length > faceStart) {
         this._faceCache3D.set(key, faces3D.slice(faceStart));
       }
     }
 
     this._dirtyKeys.clear();
-    this._faceCacheEpoch = this._epoch;
+    return faces3D;
+  }
 
-    const result = this._projectAndSort(faces3D);
+  /**
+   * Generate faces from stored voxels.
+   *
+   * By default returns projected, depth-sorted 2D faces for SVG rendering.
+   * Pass `{ raw: true }` to get all neighbour-exposed 3D faces without any
+   * camera-dependent culling or projection — the correct input for
+   * `GPURenderer.render()`, which lets the GPU handle its own backface culling.
+   *
+   * Both modes are epoch-cached: repeated calls with no scene changes are free.
+   *
+   * @param {Object} [options]
+   * @param {boolean} [options.raw=false] - Return raw 3D faces instead of projected 2D faces.
+   * @returns {Face[]}
+   */
+  getFaces(options = {}) {
+    if (options.raw) {
+      if (this._cachedRawEpoch === this._epoch && this._cachedRawFaces) {
+        return this._cachedRawFaces;
+      }
+      const result = this._buildFaces3D().filter((f) => f.type !== "content");
+      this._cachedRawFaces = result;
+      this._cachedRawEpoch = this._epoch;
+      return result;
+    }
+
+    if (this._cachedEpoch === this._epoch && this._cachedFaces) {
+      return this._cachedFaces;
+    }
+    const result = this._projectAndSort(this._buildFaces3D());
     this._cachedFaces = result;
     this._cachedEpoch = this._epoch;
     return result;
@@ -1490,6 +1345,17 @@ export class Heerich {
       }
 
       if (projection === "oblique") {
+        // Camera-direction cull: oblique only sees one horizontal face, one
+        // vertical face, and the front. Back is always hidden.
+        if (
+          face.type === "back" ||
+          (face.type === "top"    && depthOffsetY >= 0) ||
+          (face.type === "bottom" && depthOffsetY <= 0) ||
+          (face.type === "left"   && depthOffsetX >= 0) ||
+          (face.type === "right"  && depthOffsetX <= 0)
+        ) continue;
+
+        face.depth = face.c[2] - face.c[0] * dx_norm - face.c[1] * dy_norm;
         const flat = [];
         for (const v of face.vertices) {
           flat.push(

--- a/src/heerich.js
+++ b/src/heerich.js
@@ -4,7 +4,6 @@ import { Points } from "./points.js";
 import { boxCoords, sphereCoords, lineCoords, fillCoords } from "./shapes.js";
 
 export { boxCoords, sphereCoords, lineCoords, fillCoords };
-export { GPURenderer } from "./gpu-renderer.js";
 export { SVGRenderer } from "./svg-renderer.js";
 
 /**
@@ -906,7 +905,12 @@ export class Heerich {
       const faceStart = faces3D.length;
 
       if (voxel.content) {
-        faces3D.push({ type: "content", voxel, content: voxel.content, _pos: [x, y, z] });
+        faces3D.push({
+          type: "content",
+          voxel,
+          content: voxel.content,
+          _pos: [x, y, z],
+        });
         this._faceCache3D.set(key, faces3D.slice(faceStart));
         continue;
       }
@@ -925,7 +929,9 @@ export class Heerich {
       const addFace = (type, vertices, n, cx, cy, cz) => {
         let c = [cx, cy, cz];
         if (sc) {
-          const ox = x + so[0], oy = y + so[1], oz = z + so[2];
+          const ox = x + so[0],
+            oy = y + so[1],
+            oz = z + so[2];
           c = [
             ox + (cx - ox) * sc[0],
             oy + (cy - oy) * sc[1],
@@ -935,7 +941,9 @@ export class Heerich {
         faces3D.push({
           type,
           voxel,
-          vertices: sc ? Heerich._scaleVertices(vertices, x, y, z, sc, so) : vertices,
+          vertices: sc
+            ? Heerich._scaleVertices(vertices, x, y, z, sc, so)
+            : vertices,
           n,
           c,
           style: getStyle(type),
@@ -945,17 +953,89 @@ export class Heerich {
       // Emit all 6 neighbor-exposed faces. Camera-direction filtering is
       // deferred to _projectAndSort (for SVG) or left to the GPU.
       if (sc || !hasVoxel(x, y - 1, z))
-        addFace("top",    [[x,y,z],[x+1,y,z],[x+1,y,z+1],[x,y,z+1]],             [0,-1,0], x+0.5, y,   z+0.5);
+        addFace(
+          "top",
+          [
+            [x, y, z],
+            [x + 1, y, z],
+            [x + 1, y, z + 1],
+            [x, y, z + 1],
+          ],
+          [0, -1, 0],
+          x + 0.5,
+          y,
+          z + 0.5,
+        );
       if (sc || !hasVoxel(x, y + 1, z))
-        addFace("bottom", [[x,y+1,z+1],[x+1,y+1,z+1],[x+1,y+1,z],[x,y+1,z]],   [0,1,0],  x+0.5, y+1, z+0.5);
+        addFace(
+          "bottom",
+          [
+            [x, y + 1, z + 1],
+            [x + 1, y + 1, z + 1],
+            [x + 1, y + 1, z],
+            [x, y + 1, z],
+          ],
+          [0, 1, 0],
+          x + 0.5,
+          y + 1,
+          z + 0.5,
+        );
       if (sc || !hasVoxel(x - 1, y, z))
-        addFace("left",   [[x,y,z+1],[x,y,z],[x,y+1,z],[x,y+1,z+1]],             [-1,0,0], x,   y+0.5, z+0.5);
+        addFace(
+          "left",
+          [
+            [x, y, z + 1],
+            [x, y, z],
+            [x, y + 1, z],
+            [x, y + 1, z + 1],
+          ],
+          [-1, 0, 0],
+          x,
+          y + 0.5,
+          z + 0.5,
+        );
       if (sc || !hasVoxel(x + 1, y, z))
-        addFace("right",  [[x+1,y,z],[x+1,y,z+1],[x+1,y+1,z+1],[x+1,y+1,z]],   [1,0,0],  x+1, y+0.5, z+0.5);
+        addFace(
+          "right",
+          [
+            [x + 1, y, z],
+            [x + 1, y, z + 1],
+            [x + 1, y + 1, z + 1],
+            [x + 1, y + 1, z],
+          ],
+          [1, 0, 0],
+          x + 1,
+          y + 0.5,
+          z + 0.5,
+        );
       if (sc || !hasVoxel(x, y, z - 1))
-        addFace("front",  [[x,y,z],[x,y+1,z],[x+1,y+1,z],[x+1,y,z]],             [0,0,-1], x+0.5, y+0.5, z);
+        addFace(
+          "front",
+          [
+            [x, y, z],
+            [x, y + 1, z],
+            [x + 1, y + 1, z],
+            [x + 1, y, z],
+          ],
+          [0, 0, -1],
+          x + 0.5,
+          y + 0.5,
+          z,
+        );
       if (sc || !hasVoxel(x, y, z + 1))
-        addFace("back",   [[x+1,y,z+1],[x+1,y+1,z+1],[x,y+1,z+1],[x,y,z+1]],   [0,0,1],  x+0.5, y+0.5, z+1);
+        addFace(
+          "back",
+          [
+            [x + 1, y, z + 1],
+            [x + 1, y + 1, z + 1],
+            [x, y + 1, z + 1],
+            [x, y, z + 1],
+          ],
+          [0, 0, 1],
+          x + 0.5,
+          y + 0.5,
+          z + 1,
+        );
 
       if (faces3D.length > faceStart) {
         this._faceCache3D.set(key, faces3D.slice(faceStart));
@@ -972,7 +1052,7 @@ export class Heerich {
    * By default returns projected, depth-sorted 2D faces for SVG rendering.
    * Pass `{ raw: true }` to get all neighbour-exposed 3D faces without any
    * camera-dependent culling or projection — the correct input for
-   * `GPURenderer.render()`, which lets the GPU handle its own backface culling.
+   * GPURenderer, which lets the GPU handle its own backface culling.
    *
    * Both modes are epoch-cached: repeated calls with no scene changes are free.
    *
@@ -1350,11 +1430,12 @@ export class Heerich {
         // vertical face, and the front. Back is always hidden.
         if (
           face.type === "back" ||
-          (face.type === "top"    && depthOffsetY >= 0) ||
+          (face.type === "top" && depthOffsetY >= 0) ||
           (face.type === "bottom" && depthOffsetY <= 0) ||
-          (face.type === "left"   && depthOffsetX >= 0) ||
-          (face.type === "right"  && depthOffsetX <= 0)
-        ) continue;
+          (face.type === "left" && depthOffsetX >= 0) ||
+          (face.type === "right" && depthOffsetX <= 0)
+        )
+          continue;
 
         face.depth = face.c[2] - face.c[0] * dx_norm - face.c[1] * dy_norm;
         const flat = [];

--- a/src/heerich.js
+++ b/src/heerich.js
@@ -853,23 +853,32 @@ export class Heerich {
 
   /**
    * Build all neighbor-exposed 3D faces for every voxel, using the incremental
-   * per-voxel cache. Always emits all 6 faces (camera direction is irrelevant
-   * here — filtering happens in `_projectAndSort` for SVG, or in the GPU
-   * renderer's own backface culling for 3D output).
+   * per-voxel cache. Emits up to 6 faces per voxel. The `back` face (normal
+   * [0,0,1]) is included so that orthographic/isometric cameras can see it when
+   * rotated past ~90°; oblique always culls it via `cullTypes`.
    *
    * Each face carries `n` (normal) and `c` (center) so that `_projectAndSort`
    * can do backface culling and depth computation without extra lookups.
    *
+   * @param {Set<string>|null} [cullTypes] - Optional set of face type strings to
+   *   skip at generation time (e.g. oblique direction cull). When provided the
+   *   per-voxel incremental cache is bypassed so that the cache always stores
+   *   the full unculled set.
    * @returns {Object[]} Raw 3D face objects
    */
-  _buildFaces3D() {
+  _buildFaces3D(cullTypes = null) {
     const hasVoxel = (x, y, z) => {
       const v = this.voxels.get(this._k(x, y, z));
       return v && v.opaque !== false;
     };
 
     const dirtyKeys = this._dirtyKeys;
-    const useIncremental = dirtyKeys.size > 0 && this._faceCache3D.size > 0;
+    // Bypass the per-voxel cache when direction culling is active: the cache
+    // stores the full unculled set, so mixing culled and unculled entries would
+    // corrupt it. The epoch-level cache in getFaces() still avoids redundant
+    // work for static scenes.
+    const useIncremental =
+      !cullTypes && dirtyKeys.size > 0 && this._faceCache3D.size > 0;
 
     if (useIncremental) {
       for (const dk of dirtyKeys) {
@@ -911,7 +920,7 @@ export class Heerich {
           content: voxel.content,
           _pos: [x, y, z],
         });
-        this._faceCache3D.set(key, faces3D.slice(faceStart));
+        if (!cullTypes) this._faceCache3D.set(key, faces3D.slice(faceStart));
         continue;
       }
 
@@ -927,6 +936,7 @@ export class Heerich {
       const so = voxel.scaleOrigin;
 
       const addFace = (type, vertices, n, cx, cy, cz) => {
+        if (cullTypes && cullTypes.has(type)) return;
         let c = [cx, cy, cz];
         if (sc) {
           const ox = x + so[0],
@@ -950,8 +960,9 @@ export class Heerich {
         });
       };
 
-      // Emit all 6 neighbor-exposed faces. Camera-direction filtering is
-      // deferred to _projectAndSort (for SVG) or left to the GPU.
+      // Emit up to 5 neighbor-exposed faces (back is always omitted — see JSDoc).
+      // Camera-direction filtering for oblique is applied via cullTypes; other
+      // projections filter in _projectAndSort via dot-product backface culling.
       if (sc || !hasVoxel(x, y - 1, z))
         addFace(
           "top",
@@ -1036,8 +1047,7 @@ export class Heerich {
           y + 0.5,
           z + 1,
         );
-
-      if (faces3D.length > faceStart) {
+      if (!cullTypes && faces3D.length > faceStart) {
         this._faceCache3D.set(key, faces3D.slice(faceStart));
       }
     }
@@ -1074,7 +1084,23 @@ export class Heerich {
     if (this._cachedEpoch === this._epoch && this._cachedFaces) {
       return this._cachedFaces;
     }
-    const result = this._projectAndSort(this._buildFaces3D());
+
+    // For oblique projection, cull invisible faces at generation time so the
+    // hot rebuild path never allocates them. Other projections rely on the
+    // dot-product backface check in _projectAndSort and benefit from the
+    // per-voxel incremental cache, so cullTypes stays null for them.
+    let cullTypes = null;
+    if (this.renderOptions.projection === "oblique") {
+      const { depthOffsetX, depthOffsetY } = this.renderOptions;
+      cullTypes = new Set();
+      cullTypes.add("back"); // back face is never visible in oblique
+      if (depthOffsetY >= 0) cullTypes.add("top");
+      if (depthOffsetY <= 0) cullTypes.add("bottom");
+      if (depthOffsetX >= 0) cullTypes.add("left");
+      if (depthOffsetX <= 0) cullTypes.add("right");
+    }
+
+    const result = this._projectAndSort(this._buildFaces3D(cullTypes));
     this._cachedFaces = result;
     this._cachedEpoch = this._epoch;
     return result;
@@ -1339,6 +1365,8 @@ export class Heerich {
 
     const { cameraDistance } = this.renderOptions;
 
+    var calls = 0;
+
     for (const face of faces3D) {
       if (face.type === "content") {
         const [cx, cy, cz] = face._pos;
@@ -1383,6 +1411,9 @@ export class Heerich {
         ];
         if (projection === "oblique") {
           const flat = [];
+          if (calls++ > 100) {
+            debugger;
+          }
           for (const [vx, vy, vz] of corners) {
             flat.push(
               truncate(vx * tileW + vz * depthOffsetX),
@@ -1511,7 +1542,8 @@ export class Heerich {
         b.depth - a.depth ||
         a.voxel.x - b.voxel.x ||
         a.voxel.y - b.voxel.y ||
-        a.voxel.z - b.voxel.z,
+        a.voxel.z - b.voxel.z ||
+        a.type.localeCompare(b.type),
     );
     return projectedFaces;
   }

--- a/src/heerich.js
+++ b/src/heerich.js
@@ -4,6 +4,8 @@ import { Points } from "./points.js";
 import { boxCoords, sphereCoords, lineCoords, fillCoords } from "./shapes.js";
 
 export { boxCoords, sphereCoords, lineCoords, fillCoords };
+export { GPURenderer } from "./gpu-renderer.js";
+export { SVGRenderer } from "./svg-renderer.js";
 
 /**
  * @typedef {Object} StyleObject
@@ -166,16 +168,18 @@ export class Heerich {
     this._cachedEpoch = -1;
     /** @type {Face[]|null} */
     this._cachedFaces = null;
+    /** @type {number} Epoch at which _cachedRawFaces was computed */
+    this._cachedRawEpoch = -1;
+    /** @type {Face[]|null} */
+    this._cachedRawFaces = null;
     /** @type {SVGRenderer|null} */
     this._svgRenderer = null;
     /** @type {boolean} */
     this._batching = false;
-    /** @type {Set<number>} Voxel keys that changed since last getFaces */
+    /** @type {Set<number>} Voxel keys that changed since last _buildFaces3D */
     this._dirtyKeys = new Set();
     /** @type {Map<number, Object[]>} Cached 3D faces per voxel key */
     this._faceCache3D = new Map();
-    /** @type {number} Epoch at which the full cache was last valid */
-    this._faceCacheEpoch = -1;
   }
 
   /**
@@ -232,7 +236,10 @@ export class Heerich {
   /** Mark the scene as modified. */
   _invalidate() {
     this._epoch++;
-    if (!this._batching) this._cachedFaces = null;
+    if (!this._batching) {
+      this._cachedFaces = null;
+      this._cachedRawFaces = null;
+    }
   }
 
   /**
@@ -846,41 +853,25 @@ export class Heerich {
   }
 
   /**
-   * Generate an array of renderable 2D polygon faces from stored voxels, properly depth-sorted.
-   * Results are cached until the scene is modified.
-   * @returns {Face[]}
+   * Build all neighbor-exposed 3D faces for every voxel, using the incremental
+   * per-voxel cache. Always emits all 6 faces (camera direction is irrelevant
+   * here — filtering happens in `_projectAndSort` for SVG, or in the GPU
+   * renderer's own backface culling for 3D output).
+   *
+   * Each face carries `n` (normal) and `c` (center) so that `_projectAndSort`
+   * can do backface culling and depth computation without extra lookups.
+   *
+   * @returns {Object[]} Raw 3D face objects
    */
-  getFaces() {
-    if (this._cachedEpoch === this._epoch && this._cachedFaces) {
-      return this._cachedFaces;
-    }
-
-    const projectedFaces = [];
-    const {
-      projection,
-      tileW,
-      tileH,
-      depthOffsetX,
-      depthOffsetY,
-      cameraX,
-      cameraY,
-      cameraDistance,
-    } = this.renderOptions;
-
+  _buildFaces3D() {
     const hasVoxel = (x, y, z) => {
       const v = this.voxels.get(this._k(x, y, z));
       return v && v.opaque !== false;
     };
 
-    // Oblique depth constants (used in face gen and content projection)
-    const dx_norm = projection === "oblique" ? depthOffsetX / tileW : 0;
-    const dy_norm = projection === "oblique" ? depthOffsetY / tileH : 0;
-
-    // Incremental: only regenerate 3D faces for dirty voxels
     const dirtyKeys = this._dirtyKeys;
     const useIncremental = dirtyKeys.size > 0 && this._faceCache3D.size > 0;
 
-    // Remove cache entries for deleted voxels
     if (useIncremental) {
       for (const dk of dirtyKeys) {
         this._faceCache3D.delete(dk);
@@ -888,8 +879,8 @@ export class Heerich {
     }
 
     const faces3D = [];
+
     for (const [key, voxel] of this.voxels.entries()) {
-      // Reuse cached 3D faces for unchanged voxels
       if (useIncremental && !dirtyKeys.has(key)) {
         const cached = this._faceCache3D.get(key);
         if (cached) {
@@ -900,7 +891,6 @@ export class Heerich {
 
       const { x, y, z, styles } = voxel;
 
-      // Skip fully occluded voxels — all 6 neighbors are opaque
       if (
         !voxel.scale &&
         hasVoxel(x - 1, y, z) &&
@@ -915,231 +905,96 @@ export class Heerich {
 
       const faceStart = faces3D.length;
 
-      // Content voxels: emit a content entry instead of polygon faces
       if (voxel.content) {
-        faces3D.push({
-          type: "content",
-          voxel,
-          content: voxel.content,
-          _pos: [x, y, z],
-        });
+        faces3D.push({ type: "content", voxel, content: voxel.content, _pos: [x, y, z] });
         this._faceCache3D.set(key, faces3D.slice(faceStart));
         continue;
       }
 
-      // Precompute base style (default + styles.default) once per voxel
       const base = styles.default
         ? { ...this.defaultStyle, ...styles.default }
         : this.defaultStyle;
-      const getStyles = (faceName) => {
+      const getStyle = (faceName) => {
         const faceStyle = styles[faceName];
         return faceStyle ? { ...base, ...faceStyle } : base;
       };
 
-      // In Oblique projection:
-      // A standard grid relies on absolute occlusion to decide boundaries.
-      // If we just mapped raw vectors, parallel walls get confused by the math.
-      // We fall back conditionally to explicit voxel checking for oblique, but true vector calculation for perspective.
-
       const sc = voxel.scale;
       const so = voxel.scaleOrigin;
 
-      if (projection === "oblique") {
-        const getDepth = (cx, cy, cz) => cz - cx * dx_norm - cy * dy_norm;
+      const addFace = (type, vertices, n, cx, cy, cz) => {
+        let c = [cx, cy, cz];
+        if (sc) {
+          const ox = x + so[0], oy = y + so[1], oz = z + so[2];
+          c = [
+            ox + (cx - ox) * sc[0],
+            oy + (cy - oy) * sc[1],
+            oz + (cz - oz) * sc[2],
+          ];
+        }
+        faces3D.push({
+          type,
+          voxel,
+          vertices: sc ? Heerich._scaleVertices(vertices, x, y, z, sc, so) : vertices,
+          n,
+          c,
+          style: getStyle(type),
+        });
+      };
 
-        const addObliqueFace = (type, vertices, cx, cy, cz) => {
-          faces3D.push({
-            type,
-            voxel,
-            vertices: sc
-              ? Heerich._scaleVertices(vertices, x, y, z, sc, so)
-              : vertices,
-            depth: getDepth(cx, cy, cz),
-            style: getStyles(type),
-          });
-        };
+      // Emit all 6 neighbor-exposed faces. Camera-direction filtering is
+      // deferred to _projectAndSort (for SVG) or left to the GPU.
+      if (sc || !hasVoxel(x, y - 1, z))
+        addFace("top",    [[x,y,z],[x+1,y,z],[x+1,y,z+1],[x,y,z+1]],             [0,-1,0], x+0.5, y,   z+0.5);
+      if (sc || !hasVoxel(x, y + 1, z))
+        addFace("bottom", [[x,y+1,z+1],[x+1,y+1,z+1],[x+1,y+1,z],[x,y+1,z]],   [0,1,0],  x+0.5, y+1, z+0.5);
+      if (sc || !hasVoxel(x - 1, y, z))
+        addFace("left",   [[x,y,z+1],[x,y,z],[x,y+1,z],[x,y+1,z+1]],             [-1,0,0], x,   y+0.5, z+0.5);
+      if (sc || !hasVoxel(x + 1, y, z))
+        addFace("right",  [[x+1,y,z],[x+1,y,z+1],[x+1,y+1,z+1],[x+1,y+1,z]],   [1,0,0],  x+1, y+0.5, z+0.5);
+      if (sc || !hasVoxel(x, y, z - 1))
+        addFace("front",  [[x,y,z],[x,y+1,z],[x+1,y+1,z],[x+1,y,z]],             [0,0,-1], x+0.5, y+0.5, z);
+      if (sc || !hasVoxel(x, y, z + 1))
+        addFace("back",   [[x+1,y,z+1],[x+1,y+1,z+1],[x,y+1,z+1],[x,y,z+1]],   [0,0,1],  x+0.5, y+0.5, z+1);
 
-        // For oblique, we strictly cull invisible orientations
-        // Scaled voxels bypass neighbor occlusion (they don't fill the cell)
-        if (depthOffsetY < 0 && (sc || !hasVoxel(x, y - 1, z)))
-          addObliqueFace(
-            "top",
-            [
-              [x, y, z],
-              [x + 1, y, z],
-              [x + 1, y, z + 1],
-              [x, y, z + 1],
-            ],
-            x + 0.5,
-            y,
-            z + 0.5,
-          );
-        if (depthOffsetY > 0 && (sc || !hasVoxel(x, y + 1, z)))
-          addObliqueFace(
-            "bottom",
-            [
-              [x, y + 1, z + 1],
-              [x + 1, y + 1, z + 1],
-              [x + 1, y + 1, z],
-              [x, y + 1, z],
-            ],
-            x + 0.5,
-            y + 1,
-            z + 0.5,
-          );
-
-        if (depthOffsetX < 0 && (sc || !hasVoxel(x - 1, y, z)))
-          addObliqueFace(
-            "left",
-            [
-              [x, y, z + 1],
-              [x, y, z],
-              [x, y + 1, z],
-              [x, y + 1, z + 1],
-            ],
-            x,
-            y + 0.5,
-            z + 0.5,
-          );
-        if (depthOffsetX > 0 && (sc || !hasVoxel(x + 1, y, z)))
-          addObliqueFace(
-            "right",
-            [
-              [x + 1, y, z],
-              [x + 1, y, z + 1],
-              [x + 1, y + 1, z + 1],
-              [x + 1, y + 1, z],
-            ],
-            x + 1,
-            y + 0.5,
-            z + 0.5,
-          );
-
-        // Oblique depth always increases with z so the camera looks from
-        // –z.  "front" (normal –z) faces the camera; "back" (normal +z)
-        // always faces away — never visible, skip it.
-        if (sc || !hasVoxel(x, y, z - 1))
-          addObliqueFace(
-            "front",
-            [
-              [x, y, z],
-              [x, y + 1, z],
-              [x + 1, y + 1, z],
-              [x + 1, y, z],
-            ],
-            x + 0.5,
-            y + 0.5,
-            z,
-          );
-      } else {
-        // Perspective Mode uses robust 3D math and backface culling
-        const addPerspFace = (type, vertices, n, c) => {
-          if (sc) {
-            const ox = x + so[0],
-              oy = y + so[1],
-              oz = z + so[2];
-            c = [
-              ox + (c[0] - ox) * sc[0],
-              oy + (c[1] - oy) * sc[1],
-              oz + (c[2] - oz) * sc[2],
-            ];
-          }
-          faces3D.push({
-            type,
-            voxel,
-            vertices: sc
-              ? Heerich._scaleVertices(vertices, x, y, z, sc, so)
-              : vertices,
-            n,
-            c,
-            style: getStyles(type),
-          });
-        };
-
-        if (sc || !hasVoxel(x, y - 1, z))
-          addPerspFace(
-            "top",
-            [
-              [x, y, z],
-              [x + 1, y, z],
-              [x + 1, y, z + 1],
-              [x, y, z + 1],
-            ],
-            [0, -1, 0],
-            [x + 0.5, y, z + 0.5],
-          );
-        if (sc || !hasVoxel(x, y + 1, z))
-          addPerspFace(
-            "bottom",
-            [
-              [x, y + 1, z + 1],
-              [x + 1, y + 1, z + 1],
-              [x + 1, y + 1, z],
-              [x, y + 1, z],
-            ],
-            [0, 1, 0],
-            [x + 0.5, y + 1, z + 0.5],
-          );
-        if (sc || !hasVoxel(x - 1, y, z))
-          addPerspFace(
-            "left",
-            [
-              [x, y, z + 1],
-              [x, y, z],
-              [x, y + 1, z],
-              [x, y + 1, z + 1],
-            ],
-            [-1, 0, 0],
-            [x, y + 0.5, z + 0.5],
-          );
-        if (sc || !hasVoxel(x + 1, y, z))
-          addPerspFace(
-            "right",
-            [
-              [x + 1, y, z],
-              [x + 1, y, z + 1],
-              [x + 1, y + 1, z + 1],
-              [x + 1, y + 1, z],
-            ],
-            [1, 0, 0],
-            [x + 1, y + 0.5, z + 0.5],
-          );
-        if (sc || !hasVoxel(x, y, z - 1))
-          addPerspFace(
-            "front",
-            [
-              [x, y, z],
-              [x, y + 1, z],
-              [x + 1, y + 1, z],
-              [x + 1, y, z],
-            ],
-            [0, 0, -1],
-            [x + 0.5, y + 0.5, z],
-          );
-        if (sc || !hasVoxel(x, y, z + 1))
-          addPerspFace(
-            "back",
-            [
-              [x + 1, y, z + 1],
-              [x + 1, y + 1, z + 1],
-              [x, y + 1, z + 1],
-              [x, y, z + 1],
-            ],
-            [0, 0, 1],
-            [x + 0.5, y + 0.5, z + 1],
-          );
-      }
-
-      // Cache this voxel's 3D faces for incremental updates
       if (faces3D.length > faceStart) {
         this._faceCache3D.set(key, faces3D.slice(faceStart));
       }
     }
 
     this._dirtyKeys.clear();
-    this._faceCacheEpoch = this._epoch;
+    return faces3D;
+  }
 
-    const result = this._projectAndSort(faces3D);
+  /**
+   * Generate faces from stored voxels.
+   *
+   * By default returns projected, depth-sorted 2D faces for SVG rendering.
+   * Pass `{ raw: true }` to get all neighbour-exposed 3D faces without any
+   * camera-dependent culling or projection — the correct input for
+   * `GPURenderer.render()`, which lets the GPU handle its own backface culling.
+   *
+   * Both modes are epoch-cached: repeated calls with no scene changes are free.
+   *
+   * @param {Object} [options]
+   * @param {boolean} [options.raw=false] - Return raw 3D faces instead of projected 2D faces.
+   * @returns {Face[]}
+   */
+  getFaces(options = {}) {
+    if (options.raw) {
+      if (this._cachedRawEpoch === this._epoch && this._cachedRawFaces) {
+        return this._cachedRawFaces;
+      }
+      const result = this._buildFaces3D().filter((f) => f.type !== "content");
+      this._cachedRawFaces = result;
+      this._cachedRawEpoch = this._epoch;
+      return result;
+    }
+
+    if (this._cachedEpoch === this._epoch && this._cachedFaces) {
+      return this._cachedFaces;
+    }
+    const result = this._projectAndSort(this._buildFaces3D());
     this._cachedFaces = result;
     this._cachedEpoch = this._epoch;
     return result;
@@ -1491,6 +1346,17 @@ export class Heerich {
       }
 
       if (projection === "oblique") {
+        // Camera-direction cull: oblique only sees one horizontal face, one
+        // vertical face, and the front. Back is always hidden.
+        if (
+          face.type === "back" ||
+          (face.type === "top"    && depthOffsetY >= 0) ||
+          (face.type === "bottom" && depthOffsetY <= 0) ||
+          (face.type === "left"   && depthOffsetX >= 0) ||
+          (face.type === "right"  && depthOffsetX <= 0)
+        ) continue;
+
+        face.depth = face.c[2] - face.c[0] * dx_norm - face.c[1] * dy_norm;
         const flat = [];
         for (const v of face.vertices) {
           flat.push(

--- a/src/heerich.js
+++ b/src/heerich.js
@@ -5,7 +5,6 @@ import { boxCoords, sphereCoords, lineCoords, fillCoords } from "./shapes.js";
 
 export { boxCoords, sphereCoords, lineCoords, fillCoords };
 export { SVGRenderer } from "./svg-renderer.js";
-export { SVGRenderer } from "./svg-renderer.js";
 
 /**
  * @typedef {Object} StyleObject

--- a/src/heerich.js
+++ b/src/heerich.js
@@ -4,7 +4,6 @@ import { Points } from "./points.js";
 import { boxCoords, sphereCoords, lineCoords, fillCoords } from "./shapes.js";
 
 export { boxCoords, sphereCoords, lineCoords, fillCoords };
-export { GPURenderer } from "./gpu-renderer.js";
 export { SVGRenderer } from "./svg-renderer.js";
 
 /**
@@ -905,7 +904,12 @@ export class Heerich {
       const faceStart = faces3D.length;
 
       if (voxel.content) {
-        faces3D.push({ type: "content", voxel, content: voxel.content, _pos: [x, y, z] });
+        faces3D.push({
+          type: "content",
+          voxel,
+          content: voxel.content,
+          _pos: [x, y, z],
+        });
         this._faceCache3D.set(key, faces3D.slice(faceStart));
         continue;
       }
@@ -924,7 +928,9 @@ export class Heerich {
       const addFace = (type, vertices, n, cx, cy, cz) => {
         let c = [cx, cy, cz];
         if (sc) {
-          const ox = x + so[0], oy = y + so[1], oz = z + so[2];
+          const ox = x + so[0],
+            oy = y + so[1],
+            oz = z + so[2];
           c = [
             ox + (cx - ox) * sc[0],
             oy + (cy - oy) * sc[1],
@@ -934,7 +940,9 @@ export class Heerich {
         faces3D.push({
           type,
           voxel,
-          vertices: sc ? Heerich._scaleVertices(vertices, x, y, z, sc, so) : vertices,
+          vertices: sc
+            ? Heerich._scaleVertices(vertices, x, y, z, sc, so)
+            : vertices,
           n,
           c,
           style: getStyle(type),
@@ -944,17 +952,89 @@ export class Heerich {
       // Emit all 6 neighbor-exposed faces. Camera-direction filtering is
       // deferred to _projectAndSort (for SVG) or left to the GPU.
       if (sc || !hasVoxel(x, y - 1, z))
-        addFace("top",    [[x,y,z],[x+1,y,z],[x+1,y,z+1],[x,y,z+1]],             [0,-1,0], x+0.5, y,   z+0.5);
+        addFace(
+          "top",
+          [
+            [x, y, z],
+            [x + 1, y, z],
+            [x + 1, y, z + 1],
+            [x, y, z + 1],
+          ],
+          [0, -1, 0],
+          x + 0.5,
+          y,
+          z + 0.5,
+        );
       if (sc || !hasVoxel(x, y + 1, z))
-        addFace("bottom", [[x,y+1,z+1],[x+1,y+1,z+1],[x+1,y+1,z],[x,y+1,z]],   [0,1,0],  x+0.5, y+1, z+0.5);
+        addFace(
+          "bottom",
+          [
+            [x, y + 1, z + 1],
+            [x + 1, y + 1, z + 1],
+            [x + 1, y + 1, z],
+            [x, y + 1, z],
+          ],
+          [0, 1, 0],
+          x + 0.5,
+          y + 1,
+          z + 0.5,
+        );
       if (sc || !hasVoxel(x - 1, y, z))
-        addFace("left",   [[x,y,z+1],[x,y,z],[x,y+1,z],[x,y+1,z+1]],             [-1,0,0], x,   y+0.5, z+0.5);
+        addFace(
+          "left",
+          [
+            [x, y, z + 1],
+            [x, y, z],
+            [x, y + 1, z],
+            [x, y + 1, z + 1],
+          ],
+          [-1, 0, 0],
+          x,
+          y + 0.5,
+          z + 0.5,
+        );
       if (sc || !hasVoxel(x + 1, y, z))
-        addFace("right",  [[x+1,y,z],[x+1,y,z+1],[x+1,y+1,z+1],[x+1,y+1,z]],   [1,0,0],  x+1, y+0.5, z+0.5);
+        addFace(
+          "right",
+          [
+            [x + 1, y, z],
+            [x + 1, y, z + 1],
+            [x + 1, y + 1, z + 1],
+            [x + 1, y + 1, z],
+          ],
+          [1, 0, 0],
+          x + 1,
+          y + 0.5,
+          z + 0.5,
+        );
       if (sc || !hasVoxel(x, y, z - 1))
-        addFace("front",  [[x,y,z],[x,y+1,z],[x+1,y+1,z],[x+1,y,z]],             [0,0,-1], x+0.5, y+0.5, z);
+        addFace(
+          "front",
+          [
+            [x, y, z],
+            [x, y + 1, z],
+            [x + 1, y + 1, z],
+            [x + 1, y, z],
+          ],
+          [0, 0, -1],
+          x + 0.5,
+          y + 0.5,
+          z,
+        );
       if (sc || !hasVoxel(x, y, z + 1))
-        addFace("back",   [[x+1,y,z+1],[x+1,y+1,z+1],[x,y+1,z+1],[x,y,z+1]],   [0,0,1],  x+0.5, y+0.5, z+1);
+        addFace(
+          "back",
+          [
+            [x + 1, y, z + 1],
+            [x + 1, y + 1, z + 1],
+            [x, y + 1, z + 1],
+            [x, y, z + 1],
+          ],
+          [0, 0, 1],
+          x + 0.5,
+          y + 0.5,
+          z + 1,
+        );
 
       if (faces3D.length > faceStart) {
         this._faceCache3D.set(key, faces3D.slice(faceStart));
@@ -971,7 +1051,7 @@ export class Heerich {
    * By default returns projected, depth-sorted 2D faces for SVG rendering.
    * Pass `{ raw: true }` to get all neighbour-exposed 3D faces without any
    * camera-dependent culling or projection — the correct input for
-   * `GPURenderer.render()`, which lets the GPU handle its own backface culling.
+   * GPURenderer, which lets the GPU handle its own backface culling.
    *
    * Both modes are epoch-cached: repeated calls with no scene changes are free.
    *
@@ -1349,11 +1429,12 @@ export class Heerich {
         // vertical face, and the front. Back is always hidden.
         if (
           face.type === "back" ||
-          (face.type === "top"    && depthOffsetY >= 0) ||
+          (face.type === "top" && depthOffsetY >= 0) ||
           (face.type === "bottom" && depthOffsetY <= 0) ||
-          (face.type === "left"   && depthOffsetX >= 0) ||
-          (face.type === "right"  && depthOffsetX <= 0)
-        ) continue;
+          (face.type === "left" && depthOffsetX >= 0) ||
+          (face.type === "right" && depthOffsetX <= 0)
+        )
+          continue;
 
         face.depth = face.c[2] - face.c[0] * dx_norm - face.c[1] * dy_norm;
         const flat = [];

--- a/tests/benches.js
+++ b/tests/benches.js
@@ -1,0 +1,51 @@
+// Run all benches and print a consolidated Markdown report.
+// Run: node tests/benches.js
+
+import { run as runGetFaces } from "./getFaces.bench.js";
+import { run as runToSVG } from "./toSVG.bench.js";
+import { run as runIncremental } from "./incremental.bench.js";
+
+const ms = (n) => `${n.toFixed(2)} ms`;
+
+function reportGetFaces({ rows }) {
+  let out = `## getFaces()\n\nDense filled cube, cold = \`_invalidate()\` between calls, warm = cache hit.\n\n`;
+  out += `| Scene | Projection | cold | warm |\n`;
+  out += `|---|---|---|---|\n`;
+  for (const r of rows) {
+    out += `| ${r.size}³ (${r.voxels.toLocaleString()}) | ${r.projection} | ${ms(r.cold)} | ${ms(r.warm)} |\n`;
+  }
+  return out;
+}
+
+function reportToSVG({ rows }) {
+  let out = `\n## toSVG()\n\nFull render pipeline, with and without occlusion clipping.\n\n`;
+  out += `| Scene | Projection | plain | occlusion | ratio |\n`;
+  out += `|---|---|---|---|---|\n`;
+  for (const r of rows) {
+    out += `| ${r.size}³ (${r.voxels.toLocaleString()}) | ${r.projection} | ${ms(r.plain)} | ${ms(r.occluded)} | ${r.ratio.toFixed(1)}× |\n`;
+  }
+  return out;
+}
+
+function reportIncremental({ rows, meta }) {
+  let out = `\n## Incremental updates\n\n${meta.size}³ = ${meta.voxels.toLocaleString()} voxels. Single-voxel mutation should be much faster than a cold rebuild — if it isn't, the per-voxel cache isn't paying its way.\n\n`;
+  out += `| | median |\n|---|---|\n`;
+  for (const r of rows) out += `| ${r.label} | ${r.time.toFixed(3)} ms |\n`;
+  const [cold, incr] = rows;
+  const speedup = cold.time / incr.time;
+  out += `\n**Speedup: ${speedup.toFixed(2)}×** ${speedup < 2 ? "— suspiciously low, cache may not be helping" : ""}\n`;
+  return out;
+}
+
+const startedAt = new Date().toISOString();
+const t0 = performance.now();
+
+console.log(`# Heerich benchmark report\n`);
+console.log(`_${startedAt}  ·  node ${process.version}  ·  ${process.platform} ${process.arch}_\n`);
+
+process.stdout.write(reportGetFaces(runGetFaces()));
+process.stdout.write(reportToSVG(runToSVG()));
+process.stdout.write(reportIncremental(runIncremental()));
+
+const elapsed = ((performance.now() - t0) / 1000).toFixed(1);
+console.log(`\n_total: ${elapsed}s_`);

--- a/tests/cache-diag.js
+++ b/tests/cache-diag.js
@@ -1,0 +1,134 @@
+// Diagnostic: is the incremental cache actually being hit?
+// Instruments _faceCache3D via a Proxy to count hits/misses on getFaces().
+
+import { Heerich } from "../src/heerich.js";
+
+function instrument(h) {
+  const real = h._faceCache3D;
+  let gets = 0,
+    hits = 0,
+    sets = 0,
+    deletes = 0;
+  h._faceCache3D = new Proxy(real, {
+    get(target, prop) {
+      if (prop === "get") {
+        return (k) => {
+          gets++;
+          const v = target.get(k);
+          if (v !== undefined) hits++;
+          return v;
+        };
+      }
+      if (prop === "set") {
+        return (k, v) => {
+          sets++;
+          return target.set(k, v);
+        };
+      }
+      if (prop === "delete") {
+        return (k) => {
+          deletes++;
+          return target.delete(k);
+        };
+      }
+      const v = target[prop];
+      return typeof v === "function" ? v.bind(target) : v;
+    },
+  });
+  return () => ({
+    gets,
+    hits,
+    sets,
+    deletes,
+    size: real.size,
+    reset() {
+      gets = hits = sets = deletes = 0;
+    },
+  });
+}
+
+function scene(size) {
+  const h = new Heerich();
+  h.applyGeometry({
+    type: "box",
+    position: [0, 0, 0],
+    size: [size, size, size],
+  });
+  return h;
+}
+
+// Dense 40³
+{
+  const h = scene(40);
+  const stats = instrument(h);
+  h.getFaces(); // prime
+  console.log("── dense 40³ cube ──");
+  console.log(`  after prime: cache size=${stats().size}`);
+  stats().reset();
+
+  h.applyGeometry({
+    type: "box",
+    mode: "subtract",
+    position: [0, 0, 0],
+    size: [1, 1, 1],
+  });
+  console.log(`  dirty keys after 1-voxel subtract: ${h._dirtyKeys.size}`);
+  h.getFaces();
+  const s = stats();
+  console.log(
+    `  after incremental getFaces: gets=${s.gets} hits=${s.hits} sets=${s.sets} deletes=${s.deletes}  (${s.hits}/${s.gets} = ${((s.hits / s.gets) * 100).toFixed(1)}% hit)`,
+  );
+  console.log(`  total voxels: ${h.voxels.size}`);
+}
+
+// Sparse: hollow sphere shell at 40³
+{
+  const h = new Heerich();
+  h.applyGeometry({
+    type: "sphere",
+    center: [20, 20, 20],
+    radius: 20,
+  });
+  h.applyGeometry({
+    type: "sphere",
+    mode: "subtract",
+    center: [20, 20, 20],
+    radius: 18,
+  });
+  console.log(`\n── sparse hollow sphere shell ──`);
+  console.log(`  total voxels: ${h.voxels.size}`);
+
+  const stats = instrument(h);
+  h.getFaces();
+  console.log(`  after prime: cache size=${stats().size}`);
+  stats().reset();
+
+  // Time a cold rebuild
+  const coldT = (() => {
+    const t = performance.now();
+    for (let i = 0; i < 20; i++) {
+      h._invalidate();
+      h.getFaces();
+    }
+    return (performance.now() - t) / 20;
+  })();
+
+  // Time incremental mutation
+  const incrT = (() => {
+    const t = performance.now();
+    for (let i = 0; i < 20; i++) {
+      h.applyGeometry({
+        type: "box",
+        mode: i & 1 ? "subtract" : "union",
+        position: [i % 10, 0, 0],
+        size: [1, 1, 1],
+      });
+      h.getFaces();
+    }
+    return (performance.now() - t) / 20;
+  })();
+
+  console.log(`  cold rebuild median: ${coldT.toFixed(3)} ms`);
+  console.log(`  incremental median : ${incrT.toFixed(3)} ms`);
+  console.log(`  speedup: ${(coldT / incrT).toFixed(2)}×`);
+}

--- a/tests/getFaces.bench.js
+++ b/tests/getFaces.bench.js
@@ -1,0 +1,80 @@
+// Benchmark getFaces() across projections and scene sizes.
+// Run: node bench/getFaces.bench.js
+//
+// Designed to be runnable on both `main` and the PR branch without edits,
+// so results can be compared side-by-side. Uses the ESM source directly.
+
+import { Heerich } from "../src/heerich.js";
+
+const SIZES = [10, 25, 40];
+const PROJECTIONS = ["oblique", "perspective", "orthographic"];
+const WARMUP = 5;
+const ITERS = 30;
+
+function buildScene(size) {
+  const h = new Heerich();
+  // Dense filled cube — worst case for face generation cost.
+  h.batch(() => {
+    h.applyGeometry({
+      type: "box",
+      position: [0, 0, 0],
+      size: [size, size, size],
+    });
+  });
+  return h;
+}
+
+function bench(label, fn) {
+  for (let i = 0; i < WARMUP; i++) fn();
+  const samples = [];
+  for (let i = 0; i < ITERS; i++) {
+    const t = performance.now();
+    fn();
+    samples.push(performance.now() - t);
+  }
+  samples.sort((a, b) => a - b);
+  const median = samples[Math.floor(samples.length / 2)];
+  const min = samples[0];
+  const mean = samples.reduce((a, b) => a + b, 0) / samples.length;
+  return { label, median, min, mean };
+}
+
+function fmt(n) {
+  return n.toFixed(2).padStart(8) + " ms";
+}
+
+console.log(`node ${process.version}`);
+console.log(
+  `warmup=${WARMUP} iters=${ITERS}   (each iter invalidates cache via a no-op mutation)\n`,
+);
+
+for (const size of SIZES) {
+  const voxelCount = size * size * size;
+  console.log(`── ${size}³ = ${voxelCount.toLocaleString()} voxels ──`);
+
+  for (const projection of PROJECTIONS) {
+    const h = buildScene(size);
+    h.renderOptions.projection = projection;
+
+    // Cold: force rebuild every call by bumping epoch through _invalidate.
+    // This measures the worst case (no cache hit).
+    const cold = bench(`${projection} cold`, () => {
+      h._invalidate();
+      h.getFaces();
+    });
+
+    // Warm: first call populates cache, subsequent calls are free.
+    // Measures the cache-hit path.
+    const warm = bench(`${projection} warm`, () => {
+      h.getFaces();
+    });
+
+    console.log(
+      `  ${projection.padEnd(13)} cold median=${fmt(cold.median)} min=${fmt(cold.min)} mean=${fmt(cold.mean)}`,
+    );
+    console.log(
+      `  ${" ".repeat(13)} warm median=${fmt(warm.median)} min=${fmt(warm.min)} mean=${fmt(warm.mean)}`,
+    );
+  }
+  console.log();
+}

--- a/tests/incremental.bench.js
+++ b/tests/incremental.bench.js
@@ -1,0 +1,81 @@
+// Benchmark the incremental update path: mutate one voxel on a large scene,
+// then call getFaces(). Exercises _dirtyKeys + _faceCache3D.
+// Run directly: node tests/incremental.bench.js
+
+import { Heerich } from "../src/heerich.js";
+
+const SIZE = 40;
+const WARMUP = 5;
+const ITERS = 100;
+
+function buildScene() {
+  const h = new Heerich();
+  h.applyGeometry({
+    type: "box",
+    position: [0, 0, 0],
+    size: [SIZE, SIZE, SIZE],
+  });
+  return h;
+}
+
+function bench(fn) {
+  for (let i = 0; i < WARMUP; i++) fn(i);
+  const samples = [];
+  for (let i = 0; i < ITERS; i++) {
+    const t = performance.now();
+    fn(i + WARMUP);
+    samples.push(performance.now() - t);
+  }
+  samples.sort((a, b) => a - b);
+  return {
+    median: samples[Math.floor(samples.length / 2)],
+    min: samples[0],
+    mean: samples.reduce((a, b) => a + b, 0) / samples.length,
+  };
+}
+
+export function run() {
+  const rows = [];
+
+  {
+    const h = buildScene();
+    const r = bench(() => {
+      h._invalidate();
+      h.getFaces();
+    });
+    rows.push({ label: "cold rebuild (baseline)", time: r.median });
+  }
+
+  {
+    const h = buildScene();
+    h.getFaces();
+    const r = bench((i) => {
+      const x = i % SIZE;
+      const mode = i & 1 ? "subtract" : "union";
+      h.applyGeometry({
+        type: "box",
+        mode,
+        position: [x, 0, 0],
+        size: [1, 1, 1],
+      });
+      h.getFaces();
+    });
+    rows.push({ label: "single-voxel mutation", time: r.median });
+  }
+
+  return {
+    name: "incremental",
+    rows,
+    meta: { warmup: WARMUP, iters: ITERS, size: SIZE, voxels: SIZE ** 3 },
+  };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const { rows, meta } = run();
+  console.log(
+    `node ${process.version}   ${meta.size}³ = ${meta.voxels.toLocaleString()} voxels   warmup=${meta.warmup} iters=${meta.iters}\n`,
+  );
+  for (const r of rows) {
+    console.log(`  ${r.label.padEnd(30)} ${r.time.toFixed(3).padStart(8)} ms`);
+  }
+}

--- a/tests/toSVG.bench.js
+++ b/tests/toSVG.bench.js
@@ -1,22 +1,20 @@
-// Benchmark getFaces() across projections and scene sizes.
-// Run directly: node tests/getFaces.bench.js
-// Or import { run } to collect structured results.
+// Benchmark toSVG() — full face-gen → project → serialize pipeline,
+// with and without occlusion clipping (the expensive path in real usage).
+// Run directly: node tests/toSVG.bench.js
 
 import { Heerich } from "../src/heerich.js";
 
-const SIZES = [10, 25, 40];
-const PROJECTIONS = ["oblique", "perspective", "orthographic"];
-const WARMUP = 5;
-const ITERS = 30;
+const SIZES = [15, 25];
+const PROJECTIONS = ["oblique", "perspective"];
+const WARMUP = 3;
+const ITERS = 15;
 
 function buildScene(size) {
   const h = new Heerich();
-  h.batch(() => {
-    h.applyGeometry({
-      type: "box",
-      position: [0, 0, 0],
-      size: [size, size, size],
-    });
+  h.applyGeometry({
+    type: "box",
+    position: [0, 0, 0],
+    size: [size, size, size],
   });
   return h;
 }
@@ -43,21 +41,25 @@ export function run() {
     for (const projection of PROJECTIONS) {
       const h = buildScene(size);
       h.renderOptions.projection = projection;
-      const cold = bench(() => {
+      const plain = bench(() => {
         h._invalidate();
-        h.getFaces();
+        h.toSVG();
       });
-      const warm = bench(() => h.getFaces());
+      const occluded = bench(() => {
+        h._invalidate();
+        h.toSVG({ occlusion: true });
+      });
       rows.push({
         size,
         voxels: size ** 3,
         projection,
-        cold: cold.median,
-        warm: warm.median,
+        plain: plain.median,
+        occluded: occluded.median,
+        ratio: occluded.median / plain.median,
       });
     }
   }
-  return { name: "getFaces", rows, meta: { warmup: WARMUP, iters: ITERS } };
+  return { name: "toSVG", rows, meta: { warmup: WARMUP, iters: ITERS } };
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
@@ -65,7 +67,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
   console.log(`node ${process.version}   warmup=${meta.warmup} iters=${meta.iters}\n`);
   for (const r of rows) {
     console.log(
-      `  ${r.size}³ ${r.projection.padEnd(13)} cold=${r.cold.toFixed(2).padStart(7)} ms  warm=${r.warm.toFixed(2).padStart(7)} ms`,
+      `  ${r.size}³ ${r.projection.padEnd(12)} plain=${r.plain.toFixed(2).padStart(7)} ms  occ=${r.occluded.toFixed(2).padStart(7)} ms  (${r.ratio.toFixed(1)}×)`,
     );
   }
 }


### PR DESCRIPTION
Setting to draft so we can discuss as this update is somewhat destructive and opinionated.

Updating Heerich with options for getting raw faces - necessary for 3D rendering as face culling is offloaded to the GPU. As a side effect of this change, we now calculate all faces prior to culling in the renderer, but tests performed have shown this increase in cost negligable, compared to the alternative, which is to have a completely separate function for generating raw faces - LMK how you feel about this.

This also has the side effect of somewhat simplifying the way oblique projection is calculated.