### PR TITLE
Feature/gpu renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,51 @@ for (const face of faces) {
 }
 ```
 
+### `GPURenderer`
+
+Convert voxel faces into typed arrays ready to upload to a WebGL or WebGPU buffer (e.g. Three.js `BufferGeometry`). Each visible quad face is triangulated into two CCW triangles.
+
+```js
+import { Heerich, GPURenderer } from 'heerich'
+import * as THREE from 'three'
+
+const engine = new Heerich()
+engine.addGeometry({ type: 'box', position: [0, 0, 0], size: [4, 4, 4] })
+
+const { position, normal, uv, index } = new GPURenderer().render(
+  engine.getFaces({ raw: true }), // all neighbour-exposed faces, no camera culling
+  { yUp: true },                  // convert to Three.js coordinate space
+)
+
+const geo = new THREE.BufferGeometry()
+geo.setAttribute('position', new THREE.BufferAttribute(position, 3))
+geo.setAttribute('normal',   new THREE.BufferAttribute(normal,   3))
+geo.setAttribute('uv',       new THREE.BufferAttribute(uv,       2))
+geo.setIndex(new THREE.BufferAttribute(index, 1))
+scene.add(new THREE.Mesh(geo, new THREE.MeshStandardMaterial()))
+```
+
+`render(faces, options?)` options:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `yUp` | boolean | `false` | Convert from Heerich's Y-down/Z-into-screen space to Three.js Y-up/Z-toward-viewer by negating Y and Z. Winding is preserved (determinant +1). Without this, apply `mesh.rotation.x = Math.PI` in Three.js — do **not** use `scale.y = -1`, which changes handedness and breaks winding. |
+| `scale` | number | `1` | Uniform scale applied to vertex positions. Useful for converting voxel grid units to world-space metres. |
+| `color` | boolean | `false` | Parse `face.style.fill` and include a `color` Float32Array with RGB floats (0–1) per vertex. |
+| `defaultColor` | `[r,g,b]` | `[1,1,1]` | Fallback colour when `color` is true and a face has no parseable fill. Handles `#rgb`, `#rrggbb`, `rgb()`, and `rgba()`. |
+
+Returns a `GPUGeometry` object:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `position` | `Float32Array` | XYZ vertex positions (3 floats/vertex) |
+| `normal` | `Float32Array` | XYZ face normals, flat-shaded (3 floats/vertex) |
+| `uv` | `Float32Array` | UV texture coordinates (2 floats/vertex) |
+| `index` | `Uint32Array` | Triangle indices (3 indices/triangle) |
+| `color` | `Float32Array` | RGB vertex colours (3 floats/vertex) — present when `options.color` is true |
+| `faceCount` | number | Number of quad faces encoded |
+| `vertexCount` | number | Total vertices (`faceCount × 4`) |
+
 ### `getBounds(padding?, faces?)`
 
 Compute the 2D bounding box of the rendered geometry:

--- a/README.md
+++ b/README.md
@@ -493,6 +493,9 @@ Get the projected 2D face array directly (for custom renderers or Canvas output)
 // From stored voxels
 const faces = h.getFaces()
 
+// Raw 3D faces (no projection or backface culling) — for GPU renderers
+const raw = h.getFaces({ raw: true })
+
 // Stateless — from a test function, no voxels stored
 const faces = h.renderTest({
   bounds: [[-10, -10, -10], [10, 10, 10]],
@@ -504,9 +507,11 @@ const faces = h.renderTest({
 const svg = h.toSVG({ faces })
 ```
 
+Pass `{ raw: true }` to get all neighbour-exposed 3D faces without camera-dependent culling or projection. Raw faces keep their original 3D coordinates — useful for GPU renderers that handle their own backface culling and projection.
+
 ### Custom Renderers
 
-`getFaces()` returns everything you need to build your own renderer. Each face has:
+`getFaces()` returns everything you need to build your own renderer. Each projected face has:
 
 - `face.points` — projected 2D coordinates (flat array via `face.points.data`: `[x0, y0, x1, y1, ...]`)
 - `face.style` — resolved style object (`fill`, `stroke`, `strokeWidth`, etc.)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "heerich",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "heerich",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "devDependencies": {
         "prettier": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "heerich",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "A tiny engine for 3D voxel scenes rendered to SVG",
   "type": "module",
   "main": "./dist/heerich.umd.cjs",

--- a/site/gpu.html
+++ b/site/gpu.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Heerich — GPU Renderer WebGL Demo</title>
+    <style>
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      html,
+      body {
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+        background: #080810;
+      }
+      canvas {
+        display: block;
+        width: 100%;
+        height: 100%;
+        touch-action: none;
+      }
+      #label {
+        position: fixed;
+        bottom: 24px;
+        left: 50%;
+        transform: translateX(-50%);
+        color: rgba(255, 255, 255, 0.28);
+        font:
+          300 12px/1 system-ui,
+          sans-serif;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        pointer-events: none;
+        white-space: nowrap;
+      }
+      #stats {
+        position: fixed;
+        top: 20px;
+        right: 20px;
+        color: rgba(255, 255, 255, 0.25);
+        font:
+          300 11px/1.6 ui-monospace,
+          monospace;
+        letter-spacing: 0.05em;
+        pointer-events: none;
+        text-align: right;
+      }
+    </style>
+  </head>
+  <body>
+    <canvas id="canvas" />
+    <div id="label">drag to orbit &nbsp;·&nbsp; heerich gpu renderer</div>
+    <div id="stats"></div>
+
+    <script type="module" src="./gpu/main.js"></script>
+  </body>
+</html>

--- a/site/gpu/generate.js
+++ b/site/gpu/generate.js
@@ -1,0 +1,188 @@
+import { THREE } from "./three.js";
+import { Heerich, GPURenderer } from "../../src/heerich.js";
+import { PARAMS } from "./params.js";
+import { scene } from "./scene.js";
+
+//  PRNG
+export function mulberry32(seed) {
+  let s = seed >>> 0;
+  return () => {
+    s = (s + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(s ^ (s >>> 15), 1 | s);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const FACES = [
+  [1, 0, 0],
+  [-1, 0, 0],
+  [0, -1, 0],
+  [0, 1, 0],
+  [0, 0, 1],
+  [0, 0, -1],
+];
+
+function dot3(a, b) {
+  return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+}
+
+//  Helpers
+export function hsl(h, s, l) {
+  s /= 100;
+  l /= 100;
+  const a = s * Math.min(l, 1 - l);
+  const f = (n) => {
+    const k = (n + h / 30) % 12;
+    return Math.round((l - a * Math.max(-1, Math.min(k - 3, 9 - k, 1))) * 255)
+      .toString(16)
+      .padStart(2, "0");
+  };
+  return `#${f(0)}${f(8)}${f(4)}`;
+}
+
+//  Voxel CFDG expansion
+export function expand(rng) {
+  const MAX_VOXELS = 10000;
+  const voxels = [];
+  const queue = [
+    { x: 0, y: 0, z: 0, size: PARAMS.rootSize, depth: 0, fromDir: null },
+  ];
+
+  while (queue.length > 0 && voxels.length < MAX_VOXELS) {
+    const { x, y, z, size, depth, fromDir } = queue.shift();
+    const iSize = Math.max(1, Math.round(size));
+    voxels.push({
+      x: Math.round(x),
+      y: Math.round(y),
+      z: Math.round(z),
+      size: iSize,
+      depth,
+    });
+
+    const childSize = size * PARAMS.scaleDecay;
+    if (depth >= PARAMS.maxDepth || childSize < 0.5) continue;
+
+    const iChildSize = Math.max(1, Math.round(childSize));
+    const step = (iSize * 0.5 + iChildSize * 0.5) * PARAMS.spread;
+
+    for (const face of FACES) {
+      let prob;
+      if (!fromDir) {
+        prob = 0.5 + -face[1] * PARAMS.upBias * 0.4;
+      } else {
+        const d = dot3(face, fromDir);
+        if (d < 0) continue;
+        prob = d > 0 ? PARAMS.trunkChance : PARAMS.sideChance;
+      }
+      if (rng() <= prob) {
+        queue.push({
+          x: x + face[0] * step,
+          y: y + face[1] * step,
+          z: z + face[2] * step,
+          size: childSize,
+          depth: depth + 1,
+          fromDir: face,
+        });
+      }
+    }
+  }
+  return voxels;
+}
+
+//  Mesh builder
+export function buildMesh(faces) {
+  const { position, normal, uv, index, color } = new GPURenderer().render(
+    faces,
+    { color: true },
+  );
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute("position", new THREE.BufferAttribute(position, 3));
+  geo.setAttribute("normal", new THREE.BufferAttribute(normal, 3));
+  geo.setAttribute("uv", new THREE.BufferAttribute(uv, 2));
+  geo.setAttribute("color", new THREE.BufferAttribute(color, 3));
+  geo.setIndex(new THREE.BufferAttribute(index, 1));
+  const m = new THREE.Mesh(geo);
+  m.rotation.x = -Math.PI / 2;
+  m.castShadow = true;
+  m.receiveShadow = true;
+  return m;
+}
+
+//  Mutable mesh state (live bindings — importers always see current value)
+export let mesh = null;
+export let mat = null;
+export let emissiveMesh = null;
+export let emissiveMat = null;
+
+//  Generate
+export function generate() {
+  const rng = mulberry32(PARAMS.seed);
+  const emRng = mulberry32(PARAMS.seed ^ 0x9e3779b9);
+  const voxels = expand(rng);
+
+  const heerichOpts = {
+    tile: 10,
+    camera: { type: "orthographic", angle: 45, pitch: 35 },
+  };
+  const engine = new Heerich(heerichOpts);
+  const emissiveEngine = new Heerich(heerichOpts);
+
+  for (const { x, y, z, size, depth } of voxels) {
+    const t = depth / Math.max(PARAMS.maxDepth, 1);
+    const hue = (PARAMS.hueStart + t * PARAMS.hueRange) % 360;
+    const lit = 56 - t * 32;
+    const jitter = [
+      rng() * 0.01 - 0.005,
+      rng() * 0.01 - 0.005,
+      rng() * 0.01 - 0.005,
+    ];
+    const geomArgs = {
+      type: "box",
+      center: [x + jitter[0], y + jitter[1], z + jitter[2]],
+      scale: [size, size, size],
+      scaleOrigin: [0.5, 0.5, 0.5],
+      size: 1,
+      mode: "union",
+      style: {
+        default: { fill: hsl(hue, 52 * PARAMS.sat, lit) },
+        top: { fill: hsl(hue, 52 * PARAMS.sat, Math.min(lit + 14, 90)) },
+        bottom: { fill: hsl(hue, 52 * PARAMS.sat, Math.max(lit - 14, 10)) },
+      },
+    };
+    const isEmissive = size === 1 && emRng() < PARAMS.emissiveChance;
+    (isEmissive ? emissiveEngine : engine).addGeometry(geomArgs);
+  }
+
+  if (mesh) {
+    mesh.geometry.dispose();
+    mat.dispose();
+    scene.remove(mesh);
+  }
+  if (emissiveMesh) {
+    emissiveMesh.geometry.dispose();
+    emissiveMat.dispose();
+    scene.remove(emissiveMesh);
+  }
+
+  mat = new THREE.MeshPhysicalMaterial({
+    vertexColors: true,
+    roughness: PARAMS.roughness,
+    metalness: 0,
+    depthWrite: true,
+  });
+  mesh = buildMesh(engine.getFaces({ raw: true }));
+  mesh.material = mat;
+  scene.add(mesh);
+
+  emissiveMat = new THREE.MeshPhysicalMaterial({
+    vertexColors: true,
+    emissive: new THREE.Color(PARAMS.emissiveColor),
+    emissiveIntensity: PARAMS.emissiveIntensity,
+    roughness: 0.0,
+    metalness: 0.0,
+  });
+  emissiveMesh = buildMesh(emissiveEngine.getFaces({ raw: true }));
+  emissiveMesh.material = emissiveMat;
+  scene.add(emissiveMesh);
+}

--- a/site/gpu/main.js
+++ b/site/gpu/main.js
@@ -1,0 +1,50 @@
+import { THREE, OrbitControls } from "./three.js";
+import { PARAMS, focusDistUniform } from "./params.js";
+import { generate } from "./generate.js";
+import { camera, sunLight, csm } from "./scene.js";
+import { renderer } from "./renderer.js";
+import { setupPostProcessing } from "./postprocessing.js";
+import { setupPane } from "./pane.js";
+
+console.clear();
+
+const controls = new OrbitControls(camera, renderer.domElement);
+controls.enableDamping = true;
+controls.dampingFactor = 0.06;
+
+async function init() {
+  await renderer.init();
+
+  const postProcessing = setupPostProcessing();
+
+  generate();
+  setupPane();
+
+  renderer.setAnimationLoop(async () => {
+    controls.update();
+
+    if (PARAMS.sunLocked) {
+      const offset = new THREE.Vector3(-50, 60, 20);
+      offset.applyQuaternion(camera.quaternion);
+      sunLight.position.copy(camera.position).add(offset);
+      sunLight.lookAt(0, 0, 0);
+    }
+
+    if (csm.mainFrustum) csm.updateFrustums();
+
+    if (PARAMS.dofAutoFocus) {
+      focusDistUniform.value = camera.position.distanceTo(controls.target);
+    }
+
+    postProcessing.render();
+  });
+}
+
+window.addEventListener("resize", () => {
+  camera.aspect = innerWidth / innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(innerWidth, innerHeight);
+  csm.updateFrustums();
+});
+
+init();

--- a/site/gpu/pane.js
+++ b/site/gpu/pane.js
@@ -1,0 +1,142 @@
+import { Pane } from "https://esm.sh/tweakpane";
+import { PARAMS, focusDistUniform, focalRangeUniform, bokehUniform } from "./params.js";
+import { camera, sunLight, backgroundSphere } from "./scene.js";
+import { renderer, canvas } from "./renderer.js";
+import { bloomPass } from "./postprocessing.js";
+import { generate, emissiveMat } from "./generate.js";
+
+export function setupPane() {
+  const pane = new Pane({ title: "Voxel CFDG — TSL", expanded: false });
+
+  pane
+    .addBinding(PARAMS, "seed", { min: 0, max: 9999, step: 1, label: "seed" })
+    .on("change", generate);
+
+  const heerich = pane.addFolder({ title: "Context free system", expanded: false });
+  heerich.addBinding(PARAMS, "maxDepth",    { min: 2,   max: 30,   step: 1,    label: "max depth"  });
+  heerich.addBinding(PARAMS, "rootSize",    { min: 2,   max: 20,   step: 1,    label: "root size"  });
+  heerich.addBinding(PARAMS, "trunkChance", { min: 0,   max: 1,    step: 0.01, label: "trunk prob" });
+  heerich.addBinding(PARAMS, "sideChance",  { min: 0,   max: 0.8,  step: 0.01, label: "side prob"  });
+  heerich.addBinding(PARAMS, "scaleDecay",  { min: 0.3, max: 0.95, step: 0.01, label: "scale decay"});
+  heerich.addBinding(PARAMS, "spread",      { min: 0.9, max: 2.0,  step: 0.01, label: "spread"     });
+  heerich.addBinding(PARAMS, "upBias",      { min: -1,  max: 1,    step: 0.05, label: "up bias"    });
+  heerich.addBinding(PARAMS, "hueStart",    { min: 0,   max: 360,  step: 1,    label: "hue start"  });
+  heerich.addBinding(PARAMS, "hueRange",    { min: 0,   max: 360,  step: 1,    label: "hue range"  });
+  heerich.addBinding(PARAMS, "sat",         { min: 0,   max: 1,    step: 0.01, label: "Saturation" });
+  heerich
+    .addBinding(PARAMS, "bgColor", { label: "background" })
+    .on("change", ({ value }) => {
+      backgroundSphere.material.color.set(value);
+    });
+
+  const presets = pane.addFolder({ title: "Presets", expanded: false });
+  presets.addButton({ title: "Sparse tree" }).on("click", () => {
+    Object.assign(PARAMS, { trunkChance: 0.9, sideChance: 0.15 });
+    pane.refresh();
+    generate();
+  });
+  presets.addButton({ title: "Dense coral" }).on("click", () => {
+    Object.assign(PARAMS, { trunkChance: 0.6, sideChance: 0.5 });
+    pane.refresh();
+    generate();
+  });
+  presets.addButton({ title: "Fun tree" }).on("click", () => {
+    Object.assign(PARAMS, {
+      seed: 2608, maxDepth: 9, rootSize: 12, trunkChance: 0.82,
+      sideChance: 0.26, scaleDecay: 0.7, spread: 1.06, upBias: 0.65,
+      hueStart: 28, hueRange: 190,
+    });
+    pane.refresh();
+    generate();
+  });
+  presets.addButton({ title: "City tree" }).on("click", () => {
+    Object.assign(PARAMS, {
+      seed: 0, maxDepth: 24, rootSize: 12, trunkChance: 1, sideChance: 0.15,
+      scaleDecay: 0.85, spread: 1, upBias: 0.65, hueStart: 28, hueRange: 190,
+    });
+    pane.refresh();
+    generate();
+  });
+  presets.addButton({ title: "Stress test" }).on("click", () => {
+    Object.assign(PARAMS, {
+      seed: 0, maxDepth: 20, rootSize: 12, trunkChance: 0.22, sideChance: 0.26,
+      scaleDecay: 0.9, spread: 2, upBias: 0.65, hueStart: 28, hueRange: 190,
+    });
+    pane.refresh();
+    generate();
+  });
+  heerich.addButton({ title: "Randomize" }).on("click", () => {
+    PARAMS.seed        = Math.floor(Math.random() * 10000);
+    PARAMS.maxDepth    = Math.floor(Math.random() * 9) + 2;
+    PARAMS.rootSize    = Math.floor(Math.random() * 11) + 2;
+    PARAMS.trunkChance = Math.round((Math.random() * 0.9 + 0.1) * 100) / 100;
+    PARAMS.sideChance  = Math.round(Math.random() * 0.8 * 100) / 100;
+    PARAMS.scaleDecay  = Math.round((Math.random() * 0.65 + 0.3) * 100) / 100;
+    PARAMS.spread      = Math.round((Math.random() * 1.1 + 0.9) * 100) / 100;
+    PARAMS.upBias      = Math.round((Math.random() * 2 - 1) * 20) / 20;
+    PARAMS.hueStart    = Math.floor(Math.random() * 361);
+    PARAMS.hueRange    = Math.floor(Math.random() * 361);
+    pane.refresh();
+    generate();
+  });
+  heerich.addButton({ title: "Generate" }).on("click", generate);
+
+  const camFolder = pane.addFolder({ title: "Camera", expanded: false });
+  camFolder
+    .addBinding(PARAMS, "fov", { min: 10, max: 100, step: 1, label: "FOV" })
+    .on("change", ({ value }) => {
+      camera.fov = value;
+      camera.updateProjectionMatrix();
+    });
+  camFolder
+    .addBinding(PARAMS, "exposure", { min: 0.1, max: 4, step: 0.05, label: "Exposure" })
+    .on("change", ({ value }) => {
+      renderer.toneMappingExposure = value;
+    });
+  camFolder.addBinding(PARAMS, "dofAutoFocus", { label: "Auto focus" });
+  camFolder
+    .addBinding(PARAMS, "dofFocusDist", {
+      min: 1, max: 500, step: 1, label: "Focus dist",
+      disabled: PARAMS.dofAutoFocus,
+    })
+    .on("change", ({ value }) => {
+      if (!PARAMS.dofAutoFocus) focusDistUniform.value = value;
+    });
+  camFolder
+    .addBinding(PARAMS, "dofFocalRange", { min: 1, max: 200, step: 1, label: "Focal range" })
+    .on("change", ({ value }) => { focalRangeUniform.value = value; });
+  camFolder
+    .addBinding(PARAMS, "dofBokeh", { min: 0, max: 10, step: 0.1, label: "Bokeh scale" })
+    .on("change", ({ value }) => { bokehUniform.value = value; });
+
+  const ptFolder = pane.addFolder({ title: "Renderer", expanded: false });
+  ptFolder
+    .addBinding(PARAMS, "sunIntensity", { min: 0, max: 20, step: 0.5, label: "Sun intensity" })
+    .on("change", ({ value }) => { sunLight.intensity = value; });
+  ptFolder.addBinding(PARAMS, "sunLocked", { label: "Lock Sun to Cam" });
+  ptFolder
+    .addBinding(PARAMS, "bloomStrength", { min: 0, max: 3, step: 0.05, label: "Bloom strength" })
+    .on("change", ({ value }) => {
+      if (bloomPass) bloomPass.strength.value = value;
+    });
+
+  const emFolder = pane.addFolder({ title: "Emissive", expanded: false });
+  emFolder
+    .addBinding(PARAMS, "emissiveChance", { min: 0, max: 0.5, step: 0.01, label: "Chance" })
+    .on("change", generate);
+  emFolder
+    .addBinding(PARAMS, "emissiveColor", { label: "Color" })
+    .on("change", generate);
+  emFolder
+    .addBinding(PARAMS, "emissiveIntensity", { min: 0, max: 50, step: 0.5, label: "Intensity" })
+    .on("change", ({ value }) => {
+      if (emissiveMat) emissiveMat.emissiveIntensity = value;
+    });
+
+  pane.addButton({ title: "Download PNG" }).on("click", () => {
+    const a = document.createElement("a");
+    a.href = canvas.toDataURL("image/png");
+    a.download = `voxel-tsl-${PARAMS.seed}.png`;
+    a.click();
+  });
+}

--- a/site/gpu/params.js
+++ b/site/gpu/params.js
@@ -1,0 +1,43 @@
+import { uniform } from "./three.js";
+
+export const PARAMS = {
+  // voxels
+  seed: 0,
+  maxDepth: 10,
+  rootSize: 8,
+  trunkChance: 0.8,
+  sideChance: 0.18,
+  scaleDecay: 0.8,
+  spread: 1,
+  upBias: 0.5,
+  hueStart: 28,
+  hueRange: 190,
+  sat: 1,
+  bgColor: "#111122",
+  // camera
+  fov: 50,
+  exposure: 1.0,
+  // depth of field
+  dofFocusDist: 50,
+  dofFocalRange: 40,
+  dofBokeh: 2,
+  dofAutoFocus: true,
+  // lighting
+  roughness: 0.85,
+  sunIntensity: 4.0,
+  sunLocked: true,
+  aoRadius: 4,
+  // bloom
+  bloomStrength: 0.8,
+  bloomRadius: 0.5,
+  bloomThreshold: 0.2,
+  // emissive
+  emissiveChance: 0.05,
+  emissiveIntensity: 12,
+  emissiveColor: "#ffcc44",
+};
+
+// TSL uniforms — kept here so pane.js and postprocessing.js share the same instances
+export const focusDistUniform  = uniform(PARAMS.dofFocusDist);
+export const focalRangeUniform = uniform(PARAMS.dofFocalRange);
+export const bokehUniform      = uniform(PARAMS.dofBokeh);

--- a/site/gpu/postprocessing.js
+++ b/site/gpu/postprocessing.js
@@ -1,0 +1,63 @@
+import {
+  THREE,
+  pass,
+  mrt,
+  output,
+  normalView,
+  materialEmissive,
+  vec4,
+  ao,
+  bloom,
+  dof,
+} from "./three.js";
+import { PARAMS, focusDistUniform, focalRangeUniform, bokehUniform } from "./params.js";
+import { scene, camera } from "./scene.js";
+import { renderer } from "./renderer.js";
+
+// Exported as live bindings — populated after setupPostProcessing() runs
+export let gtaoPass  = null;
+export let bloomPass = null;
+
+export function setupPostProcessing() {
+  const postProcessing = new THREE.RenderPipeline(renderer);
+
+  const scenePass = pass(scene, camera);
+  scenePass.setMRT(
+    mrt({
+      output,
+      normal: normalView,
+      emissive: vec4(materialEmissive, 1.0),
+    }),
+  );
+
+  const sceneColor     = scenePass.getTextureNode("output");
+  const sceneNormal    = scenePass.getTextureNode("normal");
+  const sceneDepth     = scenePass.getTextureNode("depth");
+  const emissiveBuffer = scenePass.getTextureNode("emissive");
+
+  gtaoPass = ao(sceneDepth, sceneNormal, camera);
+  gtaoPass.radius = PARAMS.aoRadius;
+  gtaoPass.distanceExponent.value = 8;
+  gtaoPass.thickness.value = 16;
+  window.gtaoPass = gtaoPass;
+
+  const aoComposited = gtaoPass.getTextureNode().x.mul(sceneColor);
+
+  const dofNode = dof(
+    aoComposited,
+    scenePass.getViewZNode(),
+    focusDistUniform,
+    focalRangeUniform,
+    bokehUniform,
+  );
+
+  bloomPass = bloom(
+    emissiveBuffer,
+    PARAMS.bloomStrength,
+    PARAMS.bloomRadius,
+    PARAMS.bloomThreshold,
+  );
+
+  postProcessing.outputNode = dofNode.add(bloomPass);
+  return postProcessing;
+}

--- a/site/gpu/renderer.js
+++ b/site/gpu/renderer.js
@@ -1,0 +1,16 @@
+import { THREE } from "./three.js";
+import { PARAMS } from "./params.js";
+
+export const canvas = document.getElementById("canvas");
+
+export const renderer = new THREE.WebGPURenderer({
+  canvas,
+  antialias: false,
+  preserveDrawingBuffer: true,
+});
+renderer.setSize(window.innerWidth, window.innerHeight);
+renderer.setPixelRatio(2);
+renderer.toneMappingExposure = PARAMS.exposure;
+renderer.shadowMap.enabled = true;
+renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+renderer.outputEncoding = THREE.sRGBEncoding;

--- a/site/gpu/scene.js
+++ b/site/gpu/scene.js
@@ -1,0 +1,41 @@
+import { THREE, CSMShadowNode } from "./three.js";
+import { PARAMS } from "./params.js";
+
+export const scene = new THREE.Scene();
+
+const bgGeo = new THREE.SphereGeometry(400, 32, 16);
+const bgMat = new THREE.MeshPhysicalMaterial({
+  color: new THREE.Color(PARAMS.bgColor),
+  side: THREE.BackSide,
+  depthWrite: true,
+});
+export const backgroundSphere = new THREE.Mesh(bgGeo, bgMat);
+scene.add(backgroundSphere);
+
+export const camera = new THREE.PerspectiveCamera(
+  PARAMS.fov,
+  innerWidth / innerHeight,
+  1,
+  8000,
+);
+camera.position.set(-20, 40, 50);
+
+export const sunLight = new THREE.DirectionalLight(0xfff4e0, PARAMS.sunIntensity);
+sunLight.position.set(60, 120, 80);
+sunLight.castShadow = true;
+sunLight.shadow.mapSize.set(4096, 4096);
+sunLight.lookAt(0, 0, 0);
+
+export const csm = new CSMShadowNode(sunLight, {
+  camera,
+  fade: true,
+  lightIntensity: PARAMS.sunIntensity,
+  cascades: 8,
+  maxFar: 500,
+  mode: "logarithmic",
+  lightMargin: 200,
+});
+sunLight.shadow.shadowNode = csm;
+
+scene.add(sunLight);
+scene.add(new THREE.AmbientLight(0xffffff, 0.5));

--- a/site/gpu/three.js
+++ b/site/gpu/three.js
@@ -1,0 +1,18 @@
+// Single source of truth for all Three.js CDN imports.
+// Update the version pins here only.
+
+export * as THREE from "https://esm.sh/three@0.183.2/webgpu";
+export { OrbitControls } from "https://esm.sh/three@0.183.2/addons/controls/OrbitControls.js";
+export {
+  pass,
+  mrt,
+  output,
+  normalView,
+  uniform,
+  materialEmissive,
+  vec4,
+} from "https://esm.sh/three@0.183.2/tsl";
+export { CSMShadowNode } from "https://esm.sh/three@0.183.2/addons/csm/CSMShadowNode.js";
+export { ao } from "https://esm.sh/three@0.183.2/addons/tsl/display/GTAONode.js";
+export { bloom } from "https://esm.sh/three@0.183.2/addons/tsl/display/BloomNode.js";
+export { dof } from "https://esm.sh/three@0.183.2/addons/tsl/display/DepthOfFieldNode.js";

--- a/src/gpu-renderer.js
+++ b/src/gpu-renderer.js
@@ -1,0 +1,243 @@
+/**
+ * Face normals inferred from face type, used when face.n is absent (oblique projection).
+ * Heerich coordinate system: X right, Y down, Z into screen.
+ * @type {Record<string, [number,number,number]>}
+ */
+const FACE_NORMALS = {
+  top:    [ 0, -1,  0],
+  bottom: [ 0,  1,  0],
+  left:   [-1,  0,  0],
+  right:  [ 1,  0,  0],
+  front:  [ 0,  0, -1],
+  back:   [ 0,  0,  1],
+};
+
+/**
+ * UV coordinates for a quad's 4 vertices, in vertex order.
+ * U goes 0→1 left-to-right, V goes 0→1 top-to-bottom along the face.
+ */
+const QUAD_UVS = new Float32Array([0, 0, 1, 0, 1, 1, 0, 1]);
+
+/**
+ * Parse a CSS color string into [r, g, b] floats in 0–1 range.
+ * Handles #rrggbb, #rgb, rgb(r,g,b), and rgba(r,g,b,a).
+ * Returns null for unrecognised formats.
+ * @param {string} color
+ * @returns {[number,number,number]|null}
+ */
+function parseCSSColor(color) {
+  if (!color || typeof color !== "string") return null;
+  color = color.trim();
+
+  if (color[0] === "#") {
+    const hex = color.slice(1);
+    if (hex.length === 3) {
+      return [
+        parseInt(hex[0] + hex[0], 16) / 255,
+        parseInt(hex[1] + hex[1], 16) / 255,
+        parseInt(hex[2] + hex[2], 16) / 255,
+      ];
+    }
+    if (hex.length === 6) {
+      return [
+        parseInt(hex.slice(0, 2), 16) / 255,
+        parseInt(hex.slice(2, 4), 16) / 255,
+        parseInt(hex.slice(4, 6), 16) / 255,
+      ];
+    }
+    return null;
+  }
+
+  const m = color.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
+  if (m) {
+    return [+m[1] / 255, +m[2] / 255, +m[3] / 255];
+  }
+
+  return null;
+}
+
+/**
+ * @typedef {Object} GPUGeometry
+ * @property {Float32Array} position - XYZ vertex positions (3 floats per vertex)
+ * @property {Float32Array} normal   - XYZ face normals (3 floats per vertex, flat-shaded)
+ * @property {Float32Array} uv       - UV texture coordinates (2 floats per vertex)
+ * @property {Uint32Array}  index    - Triangle indices (3 indices per triangle)
+ * @property {Float32Array} [color]  - RGB vertex colours (3 floats per vertex), present when options.color is true
+ * @property {number} faceCount      - Number of quad faces encoded
+ * @property {number} vertexCount    - Total number of vertices (faceCount × 4)
+ */
+
+/**
+ * GPU renderer for Heerich voxel scenes.
+ *
+ * Converts the output of `getFaces({ raw: true })` into typed arrays ready
+ * to upload to a WebGL or WebGPU buffer (e.g. Three.js BufferGeometry).
+ *
+ * Each visible quad face is triangulated into two CCW triangles.
+ *
+ * ## Coordinate systems
+ *
+ * Heerich uses X-right / Y-down / Z-into-screen.
+ * Three.js (and most real-time engines) use X-right / Y-up / Z-toward-viewer.
+ *
+ * Pass `options.yUp = true` to convert automatically. This negates Y and Z,
+ * which is equivalent to `mesh.rotation.x = Math.PI` and has determinant +1
+ * (proper rotation), so winding is preserved without any extra flip.
+ *
+ * Without `yUp`, raw Heerich coordinates are output. In that case you must
+ * apply `mesh.rotation.x = Math.PI` (or equivalent) in Three.js yourself —
+ * do **not** use `scale.y = -1`, which changes handedness and breaks winding.
+ *
+ * @example <caption>Three.js — recommended usage</caption>
+ * import { Heerich, GPURenderer } from 'heerich';
+ * import * as THREE from 'three';
+ *
+ * const engine = new Heerich();
+ * engine.addGeometry({ type: 'box', position: [0,0,0], size: [4,4,4] });
+ *
+ * const { position, normal, uv, index } = new GPURenderer().render(
+ *   engine.getFaces({ raw: true }),  // all 6 neighbour-exposed faces, no camera pre-culling
+ *   { yUp: true },                   // convert to Three.js coordinate space
+ * );
+ *
+ * const geo = new THREE.BufferGeometry();
+ * geo.setAttribute('position', new THREE.BufferAttribute(position, 3));
+ * geo.setAttribute('normal',   new THREE.BufferAttribute(normal,   3));
+ * geo.setAttribute('uv',       new THREE.BufferAttribute(uv,       2));
+ * geo.setIndex(new THREE.BufferAttribute(index, 1));
+ * scene.add(new THREE.Mesh(geo, new THREE.MeshStandardMaterial()));
+ */
+export class GPURenderer {
+  /**
+   * Convert raw faces to typed arrays.
+   *
+   * @param {import('./heerich.js').Face[]} faces
+   *   Output of `Heerich.getFaces({ raw: true })` (recommended — all 6
+   *   neighbour-exposed faces, no camera culling). Plain `getFaces()` /
+   *   `renderTest()` also work but will be missing camera-culled faces.
+   * @param {Object} [options]
+   * @param {boolean} [options.yUp=false]
+   *   Convert from Heerich's Y-down/Z-into-screen space to Three.js
+   *   Y-up/Z-toward-viewer space by negating Y and Z. Use this when feeding
+   *   geometry directly to Three.js without any mesh transform.
+   * @param {number} [options.scale=1]
+   *   Uniform scale applied to vertex positions. Useful for converting
+   *   voxel grid units to world-space metres, etc.
+   * @param {boolean} [options.color=false]
+   *   When true, parse `face.style.fill` and include a `color` Float32Array
+   *   with RGB values (0–1) for each vertex. Unparseable colours fall back
+   *   to `options.defaultColor`.
+   * @param {[number,number,number]} [options.defaultColor=[1,1,1]]
+   *   Fallback colour used when `options.color` is true and a face has no
+   *   parseable fill value.
+   * @returns {GPUGeometry}
+   */
+  render(faces, options = {}) {
+    const scale = options.scale ?? 1;
+    const yUp = options.yUp === true;
+    const wantColor = options.color === true;
+    const defaultColor = options.defaultColor ?? [1, 1, 1];
+
+    // Negating both Y and Z converts Heerich→Three.js space.
+    // det(diag(1,-1,-1)) = +1 (proper rotation = rotation.x of PI),
+    // so winding is preserved and the crossDotN check below is unchanged.
+    const ySign = yUp ? -1 : 1;
+    const zSign = yUp ? -1 : 1;
+
+    // Count renderable quad faces (skip 'content' faces — they have no vertices)
+    let faceCount = 0;
+    for (let i = 0; i < faces.length; i++) {
+      const f = faces[i];
+      if (f.type !== "content" && f.vertices) faceCount++;
+    }
+
+    const vertexCount = faceCount * 4; // 4 verts per quad
+    const indexCount  = faceCount * 6; // 6 indices per quad (2 triangles)
+
+    const position = new Float32Array(vertexCount * 3);
+    const normal   = new Float32Array(vertexCount * 3);
+    const uv       = new Float32Array(vertexCount * 2);
+    const index    = new Uint32Array(indexCount);
+    const color    = wantColor ? new Float32Array(vertexCount * 3) : null;
+
+    let vi = 0; // next vertex slot
+    let ii = 0; // next index slot
+
+    for (let fi = 0; fi < faces.length; fi++) {
+      const face = faces[fi];
+      if (face.type === "content" || !face.vertices) continue;
+
+      const verts = face.vertices;
+      const n = face.n ?? FACE_NORMALS[face.type] ?? [0, 0, 0];
+
+      // Resolve face colour once, shared across all 4 vertices
+      let cr = defaultColor[0], cg = defaultColor[1], cb = defaultColor[2];
+      if (wantColor && face.style) {
+        const parsed = parseCSSColor(face.style.fill);
+        if (parsed) { cr = parsed[0]; cg = parsed[1]; cb = parsed[2]; }
+      }
+
+      const baseVertex = vi;
+
+      for (let i = 0; i < 4; i++) {
+        const v = verts[i];
+        const p = vi * 3;
+
+        position[p]     = v[0] * scale;
+        position[p + 1] = v[1] * scale * ySign;
+        position[p + 2] = v[2] * scale * zSign;
+
+        normal[p]     = n[0];
+        normal[p + 1] = n[1] * ySign;
+        normal[p + 2] = n[2] * zSign;
+
+        const u = vi * 2;
+        uv[u]     = QUAD_UVS[i * 2];
+        uv[u + 1] = QUAD_UVS[i * 2 + 1];
+
+        if (color) {
+          color[p]     = cr;
+          color[p + 1] = cg;
+          color[p + 2] = cb;
+        }
+
+        vi++;
+      }
+
+      // Check winding: cross(e01, e02) must agree with the face normal.
+      // Left and right faces are CW in Heerich's vertex ordering — flip those.
+      // This check uses the original (un-transformed) vertices; the result is
+      // identical after the yUp transform because det(diag(1,-1,-1)) = +1.
+      const v0 = verts[0], v1 = verts[1], v2 = verts[2];
+      const e1x = v1[0] - v0[0], e1y = v1[1] - v0[1], e1z = v1[2] - v0[2];
+      const e2x = v2[0] - v0[0], e2y = v2[1] - v0[1], e2z = v2[2] - v0[2];
+      const crossDotN =
+        (e1y * e2z - e1z * e2y) * n[0] +
+        (e1z * e2x - e1x * e2z) * n[1] +
+        (e1x * e2y - e1y * e2x) * n[2];
+
+      if (crossDotN >= 0) {
+        // CCW — standard winding
+        index[ii++] = baseVertex;
+        index[ii++] = baseVertex + 1;
+        index[ii++] = baseVertex + 2;
+        index[ii++] = baseVertex;
+        index[ii++] = baseVertex + 2;
+        index[ii++] = baseVertex + 3;
+      } else {
+        // CW — flip to make CCW
+        index[ii++] = baseVertex;
+        index[ii++] = baseVertex + 2;
+        index[ii++] = baseVertex + 1;
+        index[ii++] = baseVertex;
+        index[ii++] = baseVertex + 3;
+        index[ii++] = baseVertex + 2;
+      }
+    }
+
+    /** @type {GPUGeometry} */
+    const result = { position, normal, uv, index, faceCount, vertexCount };
+    if (color) result.color = color;
+    return result;
+  }
+}

--- a/src/heerich.js
+++ b/src/heerich.js
@@ -4,6 +4,7 @@ import { Points } from "./points.js";
 import { boxCoords, sphereCoords, lineCoords, fillCoords } from "./shapes.js";
 
 export { boxCoords, sphereCoords, lineCoords, fillCoords };
+export { SVGRenderer } from "./svg-renderer.js";
 
 /**
  * @typedef {Object} StyleObject
@@ -166,16 +167,18 @@ export class Heerich {
     this._cachedEpoch = -1;
     /** @type {Face[]|null} */
     this._cachedFaces = null;
+    /** @type {number} Epoch at which _cachedRawFaces was computed */
+    this._cachedRawEpoch = -1;
+    /** @type {Face[]|null} */
+    this._cachedRawFaces = null;
     /** @type {SVGRenderer|null} */
     this._svgRenderer = null;
     /** @type {boolean} */
     this._batching = false;
-    /** @type {Set<number>} Voxel keys that changed since last getFaces */
+    /** @type {Set<number>} Voxel keys that changed since last _buildFaces3D */
     this._dirtyKeys = new Set();
     /** @type {Map<number, Object[]>} Cached 3D faces per voxel key */
     this._faceCache3D = new Map();
-    /** @type {number} Epoch at which the full cache was last valid */
-    this._faceCacheEpoch = -1;
   }
 
   /**
@@ -232,7 +235,10 @@ export class Heerich {
   /** Mark the scene as modified. */
   _invalidate() {
     this._epoch++;
-    if (!this._batching) this._cachedFaces = null;
+    if (!this._batching) {
+      this._cachedFaces = null;
+      this._cachedRawFaces = null;
+    }
   }
 
   /**
@@ -846,41 +852,34 @@ export class Heerich {
   }
 
   /**
-   * Generate an array of renderable 2D polygon faces from stored voxels, properly depth-sorted.
-   * Results are cached until the scene is modified.
-   * @returns {Face[]}
+   * Build all neighbor-exposed 3D faces for every voxel, using the incremental
+   * per-voxel cache. Emits up to 6 faces per voxel. The `back` face (normal
+   * [0,0,1]) is included so that orthographic/isometric cameras can see it when
+   * rotated past ~90°; oblique always culls it via `cullTypes`.
+   *
+   * Each face carries `n` (normal) and `c` (center) so that `_projectAndSort`
+   * can do backface culling and depth computation without extra lookups.
+   *
+   * @param {Set<string>|null} [cullTypes] - Optional set of face type strings to
+   *   skip at generation time (e.g. oblique direction cull). When provided the
+   *   per-voxel incremental cache is bypassed so that the cache always stores
+   *   the full unculled set.
+   * @returns {Object[]} Raw 3D face objects
    */
-  getFaces() {
-    if (this._cachedEpoch === this._epoch && this._cachedFaces) {
-      return this._cachedFaces;
-    }
-
-    const projectedFaces = [];
-    const {
-      projection,
-      tileW,
-      tileH,
-      depthOffsetX,
-      depthOffsetY,
-      cameraX,
-      cameraY,
-      cameraDistance,
-    } = this.renderOptions;
-
+  _buildFaces3D(cullTypes = null) {
     const hasVoxel = (x, y, z) => {
       const v = this.voxels.get(this._k(x, y, z));
       return v && v.opaque !== false;
     };
 
-    // Oblique depth constants (used in face gen and content projection)
-    const dx_norm = projection === "oblique" ? depthOffsetX / tileW : 0;
-    const dy_norm = projection === "oblique" ? depthOffsetY / tileH : 0;
-
-    // Incremental: only regenerate 3D faces for dirty voxels
     const dirtyKeys = this._dirtyKeys;
-    const useIncremental = dirtyKeys.size > 0 && this._faceCache3D.size > 0;
+    // Bypass the per-voxel cache when direction culling is active: the cache
+    // stores the full unculled set, so mixing culled and unculled entries would
+    // corrupt it. The epoch-level cache in getFaces() still avoids redundant
+    // work for static scenes.
+    const useIncremental =
+      !cullTypes && dirtyKeys.size > 0 && this._faceCache3D.size > 0;
 
-    // Remove cache entries for deleted voxels
     if (useIncremental) {
       for (const dk of dirtyKeys) {
         this._faceCache3D.delete(dk);
@@ -888,8 +887,8 @@ export class Heerich {
     }
 
     const faces3D = [];
+
     for (const [key, voxel] of this.voxels.entries()) {
-      // Reuse cached 3D faces for unchanged voxels
       if (useIncremental && !dirtyKeys.has(key)) {
         const cached = this._faceCache3D.get(key);
         if (cached) {
@@ -900,7 +899,6 @@ export class Heerich {
 
       const { x, y, z, styles } = voxel;
 
-      // Skip fully occluded voxels — all 6 neighbors are opaque
       if (
         !voxel.scale &&
         hasVoxel(x - 1, y, z) &&
@@ -915,7 +913,6 @@ export class Heerich {
 
       const faceStart = faces3D.length;
 
-      // Content voxels: emit a content entry instead of polygon faces
       if (voxel.content) {
         faces3D.push({
           type: "content",
@@ -923,223 +920,187 @@ export class Heerich {
           content: voxel.content,
           _pos: [x, y, z],
         });
-        this._faceCache3D.set(key, faces3D.slice(faceStart));
+        if (!cullTypes) this._faceCache3D.set(key, faces3D.slice(faceStart));
         continue;
       }
 
-      // Precompute base style (default + styles.default) once per voxel
       const base = styles.default
         ? { ...this.defaultStyle, ...styles.default }
         : this.defaultStyle;
-      const getStyles = (faceName) => {
+      const getStyle = (faceName) => {
         const faceStyle = styles[faceName];
         return faceStyle ? { ...base, ...faceStyle } : base;
       };
 
-      // In Oblique projection:
-      // A standard grid relies on absolute occlusion to decide boundaries.
-      // If we just mapped raw vectors, parallel walls get confused by the math.
-      // We fall back conditionally to explicit voxel checking for oblique, but true vector calculation for perspective.
-
       const sc = voxel.scale;
       const so = voxel.scaleOrigin;
 
-      if (projection === "oblique") {
-        const getDepth = (cx, cy, cz) => cz - cx * dx_norm - cy * dy_norm;
+      const addFace = (type, vertices, n, cx, cy, cz) => {
+        if (cullTypes && cullTypes.has(type)) return;
+        let c = [cx, cy, cz];
+        if (sc) {
+          const ox = x + so[0],
+            oy = y + so[1],
+            oz = z + so[2];
+          c = [
+            ox + (cx - ox) * sc[0],
+            oy + (cy - oy) * sc[1],
+            oz + (cz - oz) * sc[2],
+          ];
+        }
+        faces3D.push({
+          type,
+          voxel,
+          vertices: sc
+            ? Heerich._scaleVertices(vertices, x, y, z, sc, so)
+            : vertices,
+          n,
+          c,
+          style: getStyle(type),
+        });
+      };
 
-        const addObliqueFace = (type, vertices, cx, cy, cz) => {
-          faces3D.push({
-            type,
-            voxel,
-            vertices: sc
-              ? Heerich._scaleVertices(vertices, x, y, z, sc, so)
-              : vertices,
-            depth: getDepth(cx, cy, cz),
-            style: getStyles(type),
-          });
-        };
-
-        // For oblique, we strictly cull invisible orientations
-        // Scaled voxels bypass neighbor occlusion (they don't fill the cell)
-        if (depthOffsetY < 0 && (sc || !hasVoxel(x, y - 1, z)))
-          addObliqueFace(
-            "top",
-            [
-              [x, y, z],
-              [x + 1, y, z],
-              [x + 1, y, z + 1],
-              [x, y, z + 1],
-            ],
-            x + 0.5,
-            y,
-            z + 0.5,
-          );
-        if (depthOffsetY > 0 && (sc || !hasVoxel(x, y + 1, z)))
-          addObliqueFace(
-            "bottom",
-            [
-              [x, y + 1, z + 1],
-              [x + 1, y + 1, z + 1],
-              [x + 1, y + 1, z],
-              [x, y + 1, z],
-            ],
-            x + 0.5,
-            y + 1,
-            z + 0.5,
-          );
-
-        if (depthOffsetX < 0 && (sc || !hasVoxel(x - 1, y, z)))
-          addObliqueFace(
-            "left",
-            [
-              [x, y, z + 1],
-              [x, y, z],
-              [x, y + 1, z],
-              [x, y + 1, z + 1],
-            ],
-            x,
-            y + 0.5,
-            z + 0.5,
-          );
-        if (depthOffsetX > 0 && (sc || !hasVoxel(x + 1, y, z)))
-          addObliqueFace(
-            "right",
-            [
-              [x + 1, y, z],
-              [x + 1, y, z + 1],
-              [x + 1, y + 1, z + 1],
-              [x + 1, y + 1, z],
-            ],
-            x + 1,
-            y + 0.5,
-            z + 0.5,
-          );
-
-        // Oblique depth always increases with z so the camera looks from
-        // –z.  "front" (normal –z) faces the camera; "back" (normal +z)
-        // always faces away — never visible, skip it.
-        if (sc || !hasVoxel(x, y, z - 1))
-          addObliqueFace(
-            "front",
-            [
-              [x, y, z],
-              [x, y + 1, z],
-              [x + 1, y + 1, z],
-              [x + 1, y, z],
-            ],
-            x + 0.5,
-            y + 0.5,
-            z,
-          );
-      } else {
-        // Perspective Mode uses robust 3D math and backface culling
-        const addPerspFace = (type, vertices, n, c) => {
-          if (sc) {
-            const ox = x + so[0],
-              oy = y + so[1],
-              oz = z + so[2];
-            c = [
-              ox + (c[0] - ox) * sc[0],
-              oy + (c[1] - oy) * sc[1],
-              oz + (c[2] - oz) * sc[2],
-            ];
-          }
-          faces3D.push({
-            type,
-            voxel,
-            vertices: sc
-              ? Heerich._scaleVertices(vertices, x, y, z, sc, so)
-              : vertices,
-            n,
-            c,
-            style: getStyles(type),
-          });
-        };
-
-        if (sc || !hasVoxel(x, y - 1, z))
-          addPerspFace(
-            "top",
-            [
-              [x, y, z],
-              [x + 1, y, z],
-              [x + 1, y, z + 1],
-              [x, y, z + 1],
-            ],
-            [0, -1, 0],
-            [x + 0.5, y, z + 0.5],
-          );
-        if (sc || !hasVoxel(x, y + 1, z))
-          addPerspFace(
-            "bottom",
-            [
-              [x, y + 1, z + 1],
-              [x + 1, y + 1, z + 1],
-              [x + 1, y + 1, z],
-              [x, y + 1, z],
-            ],
-            [0, 1, 0],
-            [x + 0.5, y + 1, z + 0.5],
-          );
-        if (sc || !hasVoxel(x - 1, y, z))
-          addPerspFace(
-            "left",
-            [
-              [x, y, z + 1],
-              [x, y, z],
-              [x, y + 1, z],
-              [x, y + 1, z + 1],
-            ],
-            [-1, 0, 0],
-            [x, y + 0.5, z + 0.5],
-          );
-        if (sc || !hasVoxel(x + 1, y, z))
-          addPerspFace(
-            "right",
-            [
-              [x + 1, y, z],
-              [x + 1, y, z + 1],
-              [x + 1, y + 1, z + 1],
-              [x + 1, y + 1, z],
-            ],
-            [1, 0, 0],
-            [x + 1, y + 0.5, z + 0.5],
-          );
-        if (sc || !hasVoxel(x, y, z - 1))
-          addPerspFace(
-            "front",
-            [
-              [x, y, z],
-              [x, y + 1, z],
-              [x + 1, y + 1, z],
-              [x + 1, y, z],
-            ],
-            [0, 0, -1],
-            [x + 0.5, y + 0.5, z],
-          );
-        if (sc || !hasVoxel(x, y, z + 1))
-          addPerspFace(
-            "back",
-            [
-              [x + 1, y, z + 1],
-              [x + 1, y + 1, z + 1],
-              [x, y + 1, z + 1],
-              [x, y, z + 1],
-            ],
-            [0, 0, 1],
-            [x + 0.5, y + 0.5, z + 1],
-          );
-      }
-
-      // Cache this voxel's 3D faces for incremental updates
-      if (faces3D.length > faceStart) {
+      // Emit up to 5 neighbor-exposed faces (back is always omitted — see JSDoc).
+      // Camera-direction filtering for oblique is applied via cullTypes; other
+      // projections filter in _projectAndSort via dot-product backface culling.
+      if (sc || !hasVoxel(x, y - 1, z))
+        addFace(
+          "top",
+          [
+            [x, y, z],
+            [x + 1, y, z],
+            [x + 1, y, z + 1],
+            [x, y, z + 1],
+          ],
+          [0, -1, 0],
+          x + 0.5,
+          y,
+          z + 0.5,
+        );
+      if (sc || !hasVoxel(x, y + 1, z))
+        addFace(
+          "bottom",
+          [
+            [x, y + 1, z + 1],
+            [x + 1, y + 1, z + 1],
+            [x + 1, y + 1, z],
+            [x, y + 1, z],
+          ],
+          [0, 1, 0],
+          x + 0.5,
+          y + 1,
+          z + 0.5,
+        );
+      if (sc || !hasVoxel(x - 1, y, z))
+        addFace(
+          "left",
+          [
+            [x, y, z + 1],
+            [x, y, z],
+            [x, y + 1, z],
+            [x, y + 1, z + 1],
+          ],
+          [-1, 0, 0],
+          x,
+          y + 0.5,
+          z + 0.5,
+        );
+      if (sc || !hasVoxel(x + 1, y, z))
+        addFace(
+          "right",
+          [
+            [x + 1, y, z],
+            [x + 1, y, z + 1],
+            [x + 1, y + 1, z + 1],
+            [x + 1, y + 1, z],
+          ],
+          [1, 0, 0],
+          x + 1,
+          y + 0.5,
+          z + 0.5,
+        );
+      if (sc || !hasVoxel(x, y, z - 1))
+        addFace(
+          "front",
+          [
+            [x, y, z],
+            [x, y + 1, z],
+            [x + 1, y + 1, z],
+            [x + 1, y, z],
+          ],
+          [0, 0, -1],
+          x + 0.5,
+          y + 0.5,
+          z,
+        );
+      if (sc || !hasVoxel(x, y, z + 1))
+        addFace(
+          "back",
+          [
+            [x + 1, y, z + 1],
+            [x + 1, y + 1, z + 1],
+            [x, y + 1, z + 1],
+            [x, y, z + 1],
+          ],
+          [0, 0, 1],
+          x + 0.5,
+          y + 0.5,
+          z + 1,
+        );
+      if (!cullTypes && faces3D.length > faceStart) {
         this._faceCache3D.set(key, faces3D.slice(faceStart));
       }
     }
 
     this._dirtyKeys.clear();
-    this._faceCacheEpoch = this._epoch;
+    return faces3D;
+  }
 
-    const result = this._projectAndSort(faces3D);
+  /**
+   * Generate faces from stored voxels.
+   *
+   * By default returns projected, depth-sorted 2D faces for SVG rendering.
+   * Pass `{ raw: true }` to get all neighbour-exposed 3D faces without any
+   * camera-dependent culling or projection — the correct input for
+   * GPURenderer, which lets the GPU handle its own backface culling.
+   *
+   * Both modes are epoch-cached: repeated calls with no scene changes are free.
+   *
+   * @param {Object} [options]
+   * @param {boolean} [options.raw=false] - Return raw 3D faces instead of projected 2D faces.
+   * @returns {Face[]}
+   */
+  getFaces(options = {}) {
+    if (options.raw) {
+      if (this._cachedRawEpoch === this._epoch && this._cachedRawFaces) {
+        return this._cachedRawFaces;
+      }
+      const result = this._buildFaces3D().filter((f) => f.type !== "content");
+      this._cachedRawFaces = result;
+      this._cachedRawEpoch = this._epoch;
+      return result;
+    }
+
+    if (this._cachedEpoch === this._epoch && this._cachedFaces) {
+      return this._cachedFaces;
+    }
+
+    // For oblique projection, cull invisible faces at generation time so the
+    // hot rebuild path never allocates them. Other projections rely on the
+    // dot-product backface check in _projectAndSort and benefit from the
+    // per-voxel incremental cache, so cullTypes stays null for them.
+    let cullTypes = null;
+    if (this.renderOptions.projection === "oblique") {
+      const { depthOffsetX, depthOffsetY } = this.renderOptions;
+      cullTypes = new Set();
+      cullTypes.add("back"); // back face is never visible in oblique
+      if (depthOffsetY >= 0) cullTypes.add("top");
+      if (depthOffsetY <= 0) cullTypes.add("bottom");
+      if (depthOffsetX >= 0) cullTypes.add("left");
+      if (depthOffsetX <= 0) cullTypes.add("right");
+    }
+
+    const result = this._projectAndSort(this._buildFaces3D(cullTypes));
     this._cachedFaces = result;
     this._cachedEpoch = this._epoch;
     return result;
@@ -1404,6 +1365,8 @@ export class Heerich {
 
     const { cameraDistance } = this.renderOptions;
 
+    var calls = 0;
+
     for (const face of faces3D) {
       if (face.type === "content") {
         const [cx, cy, cz] = face._pos;
@@ -1448,6 +1411,9 @@ export class Heerich {
         ];
         if (projection === "oblique") {
           const flat = [];
+          if (calls++ > 100) {
+            debugger;
+          }
           for (const [vx, vy, vz] of corners) {
             flat.push(
               truncate(vx * tileW + vz * depthOffsetX),
@@ -1491,6 +1457,18 @@ export class Heerich {
       }
 
       if (projection === "oblique") {
+        // Camera-direction cull: oblique only sees one horizontal face, one
+        // vertical face, and the front. Back is always hidden.
+        if (
+          face.type === "back" ||
+          (face.type === "top" && depthOffsetY >= 0) ||
+          (face.type === "bottom" && depthOffsetY <= 0) ||
+          (face.type === "left" && depthOffsetX >= 0) ||
+          (face.type === "right" && depthOffsetX <= 0)
+        )
+          continue;
+
+        face.depth = face.c[2] - face.c[0] * dx_norm - face.c[1] * dy_norm;
         const flat = [];
         for (const v of face.vertices) {
           flat.push(
@@ -1564,7 +1542,8 @@ export class Heerich {
         b.depth - a.depth ||
         a.voxel.x - b.voxel.x ||
         a.voxel.y - b.voxel.y ||
-        a.voxel.z - b.voxel.z,
+        a.voxel.z - b.voxel.z ||
+        a.type.localeCompare(b.type),
     );
     return projectedFaces;
   }

--- a/src/heerich.js
+++ b/src/heerich.js
@@ -4,6 +4,7 @@ import { Points } from "./points.js";
 import { boxCoords, sphereCoords, lineCoords, fillCoords } from "./shapes.js";
 
 export { boxCoords, sphereCoords, lineCoords, fillCoords };
+export { GPURenderer } from "./gpu-renderer.js";
 export { SVGRenderer } from "./svg-renderer.js";
 
 /**

--- a/src/heerich.js
+++ b/src/heerich.js
@@ -4,7 +4,6 @@ import { Points } from "./points.js";
 import { boxCoords, sphereCoords, lineCoords, fillCoords } from "./shapes.js";
 
 export { boxCoords, sphereCoords, lineCoords, fillCoords };
-export { GPURenderer } from "./gpu-renderer.js";
 export { SVGRenderer } from "./svg-renderer.js";
 
 /**

--- a/src/heerich.js
+++ b/src/heerich.js
@@ -4,6 +4,8 @@ import { Points } from "./points.js";
 import { boxCoords, sphereCoords, lineCoords, fillCoords } from "./shapes.js";
 
 export { boxCoords, sphereCoords, lineCoords, fillCoords };
+export { GPURenderer } from "./gpu-renderer.js";
+export { SVGRenderer } from "./svg-renderer.js";
 
 /**
  * @typedef {Object} StyleObject
@@ -165,16 +167,18 @@ export class Heerich {
     this._cachedEpoch = -1;
     /** @type {Face[]|null} */
     this._cachedFaces = null;
+    /** @type {number} Epoch at which _cachedRawFaces was computed */
+    this._cachedRawEpoch = -1;
+    /** @type {Face[]|null} */
+    this._cachedRawFaces = null;
     /** @type {SVGRenderer|null} */
     this._svgRenderer = null;
     /** @type {boolean} */
     this._batching = false;
-    /** @type {Set<number>} Voxel keys that changed since last getFaces */
+    /** @type {Set<number>} Voxel keys that changed since last _buildFaces3D */
     this._dirtyKeys = new Set();
     /** @type {Map<number, Object[]>} Cached 3D faces per voxel key */
     this._faceCache3D = new Map();
-    /** @type {number} Epoch at which the full cache was last valid */
-    this._faceCacheEpoch = -1;
   }
 
   /**
@@ -231,7 +235,10 @@ export class Heerich {
   /** Mark the scene as modified. */
   _invalidate() {
     this._epoch++;
-    if (!this._batching) this._cachedFaces = null;
+    if (!this._batching) {
+      this._cachedFaces = null;
+      this._cachedRawFaces = null;
+    }
   }
 
   /**
@@ -845,41 +852,25 @@ export class Heerich {
   }
 
   /**
-   * Generate an array of renderable 2D polygon faces from stored voxels, properly depth-sorted.
-   * Results are cached until the scene is modified.
-   * @returns {Face[]}
+   * Build all neighbor-exposed 3D faces for every voxel, using the incremental
+   * per-voxel cache. Always emits all 6 faces (camera direction is irrelevant
+   * here — filtering happens in `_projectAndSort` for SVG, or in the GPU
+   * renderer's own backface culling for 3D output).
+   *
+   * Each face carries `n` (normal) and `c` (center) so that `_projectAndSort`
+   * can do backface culling and depth computation without extra lookups.
+   *
+   * @returns {Object[]} Raw 3D face objects
    */
-  getFaces() {
-    if (this._cachedEpoch === this._epoch && this._cachedFaces) {
-      return this._cachedFaces;
-    }
-
-    const projectedFaces = [];
-    const {
-      projection,
-      tileW,
-      tileH,
-      depthOffsetX,
-      depthOffsetY,
-      cameraX,
-      cameraY,
-      cameraDistance,
-    } = this.renderOptions;
-
+  _buildFaces3D() {
     const hasVoxel = (x, y, z) => {
       const v = this.voxels.get(this._k(x, y, z));
       return v && v.opaque !== false;
     };
 
-    // Oblique depth constants (used in face gen and content projection)
-    const dx_norm = projection === "oblique" ? depthOffsetX / tileW : 0;
-    const dy_norm = projection === "oblique" ? depthOffsetY / tileH : 0;
-
-    // Incremental: only regenerate 3D faces for dirty voxels
     const dirtyKeys = this._dirtyKeys;
     const useIncremental = dirtyKeys.size > 0 && this._faceCache3D.size > 0;
 
-    // Remove cache entries for deleted voxels
     if (useIncremental) {
       for (const dk of dirtyKeys) {
         this._faceCache3D.delete(dk);
@@ -887,8 +878,8 @@ export class Heerich {
     }
 
     const faces3D = [];
+
     for (const [key, voxel] of this.voxels.entries()) {
-      // Reuse cached 3D faces for unchanged voxels
       if (useIncremental && !dirtyKeys.has(key)) {
         const cached = this._faceCache3D.get(key);
         if (cached) {
@@ -899,7 +890,6 @@ export class Heerich {
 
       const { x, y, z, styles } = voxel;
 
-      // Skip fully occluded voxels — all 6 neighbors are opaque
       if (
         !voxel.scale &&
         hasVoxel(x - 1, y, z) &&
@@ -914,231 +904,96 @@ export class Heerich {
 
       const faceStart = faces3D.length;
 
-      // Content voxels: emit a content entry instead of polygon faces
       if (voxel.content) {
-        faces3D.push({
-          type: "content",
-          voxel,
-          content: voxel.content,
-          _pos: [x, y, z],
-        });
+        faces3D.push({ type: "content", voxel, content: voxel.content, _pos: [x, y, z] });
         this._faceCache3D.set(key, faces3D.slice(faceStart));
         continue;
       }
 
-      // Precompute base style (default + styles.default) once per voxel
       const base = styles.default
         ? { ...this.defaultStyle, ...styles.default }
         : this.defaultStyle;
-      const getStyles = (faceName) => {
+      const getStyle = (faceName) => {
         const faceStyle = styles[faceName];
         return faceStyle ? { ...base, ...faceStyle } : base;
       };
 
-      // In Oblique projection:
-      // A standard grid relies on absolute occlusion to decide boundaries.
-      // If we just mapped raw vectors, parallel walls get confused by the math.
-      // We fall back conditionally to explicit voxel checking for oblique, but true vector calculation for perspective.
-
       const sc = voxel.scale;
       const so = voxel.scaleOrigin;
 
-      if (projection === "oblique") {
-        const getDepth = (cx, cy, cz) => cz - cx * dx_norm - cy * dy_norm;
+      const addFace = (type, vertices, n, cx, cy, cz) => {
+        let c = [cx, cy, cz];
+        if (sc) {
+          const ox = x + so[0], oy = y + so[1], oz = z + so[2];
+          c = [
+            ox + (cx - ox) * sc[0],
+            oy + (cy - oy) * sc[1],
+            oz + (cz - oz) * sc[2],
+          ];
+        }
+        faces3D.push({
+          type,
+          voxel,
+          vertices: sc ? Heerich._scaleVertices(vertices, x, y, z, sc, so) : vertices,
+          n,
+          c,
+          style: getStyle(type),
+        });
+      };
 
-        const addObliqueFace = (type, vertices, cx, cy, cz) => {
-          faces3D.push({
-            type,
-            voxel,
-            vertices: sc
-              ? Heerich._scaleVertices(vertices, x, y, z, sc, so)
-              : vertices,
-            depth: getDepth(cx, cy, cz),
-            style: getStyles(type),
-          });
-        };
+      // Emit all 6 neighbor-exposed faces. Camera-direction filtering is
+      // deferred to _projectAndSort (for SVG) or left to the GPU.
+      if (sc || !hasVoxel(x, y - 1, z))
+        addFace("top",    [[x,y,z],[x+1,y,z],[x+1,y,z+1],[x,y,z+1]],             [0,-1,0], x+0.5, y,   z+0.5);
+      if (sc || !hasVoxel(x, y + 1, z))
+        addFace("bottom", [[x,y+1,z+1],[x+1,y+1,z+1],[x+1,y+1,z],[x,y+1,z]],   [0,1,0],  x+0.5, y+1, z+0.5);
+      if (sc || !hasVoxel(x - 1, y, z))
+        addFace("left",   [[x,y,z+1],[x,y,z],[x,y+1,z],[x,y+1,z+1]],             [-1,0,0], x,   y+0.5, z+0.5);
+      if (sc || !hasVoxel(x + 1, y, z))
+        addFace("right",  [[x+1,y,z],[x+1,y,z+1],[x+1,y+1,z+1],[x+1,y+1,z]],   [1,0,0],  x+1, y+0.5, z+0.5);
+      if (sc || !hasVoxel(x, y, z - 1))
+        addFace("front",  [[x,y,z],[x,y+1,z],[x+1,y+1,z],[x+1,y,z]],             [0,0,-1], x+0.5, y+0.5, z);
+      if (sc || !hasVoxel(x, y, z + 1))
+        addFace("back",   [[x+1,y,z+1],[x+1,y+1,z+1],[x,y+1,z+1],[x,y,z+1]],   [0,0,1],  x+0.5, y+0.5, z+1);
 
-        // For oblique, we strictly cull invisible orientations
-        // Scaled voxels bypass neighbor occlusion (they don't fill the cell)
-        if (depthOffsetY < 0 && (sc || !hasVoxel(x, y - 1, z)))
-          addObliqueFace(
-            "top",
-            [
-              [x, y, z],
-              [x + 1, y, z],
-              [x + 1, y, z + 1],
-              [x, y, z + 1],
-            ],
-            x + 0.5,
-            y,
-            z + 0.5,
-          );
-        if (depthOffsetY > 0 && (sc || !hasVoxel(x, y + 1, z)))
-          addObliqueFace(
-            "bottom",
-            [
-              [x, y + 1, z + 1],
-              [x + 1, y + 1, z + 1],
-              [x + 1, y + 1, z],
-              [x, y + 1, z],
-            ],
-            x + 0.5,
-            y + 1,
-            z + 0.5,
-          );
-
-        if (depthOffsetX < 0 && (sc || !hasVoxel(x - 1, y, z)))
-          addObliqueFace(
-            "left",
-            [
-              [x, y, z + 1],
-              [x, y, z],
-              [x, y + 1, z],
-              [x, y + 1, z + 1],
-            ],
-            x,
-            y + 0.5,
-            z + 0.5,
-          );
-        if (depthOffsetX > 0 && (sc || !hasVoxel(x + 1, y, z)))
-          addObliqueFace(
-            "right",
-            [
-              [x + 1, y, z],
-              [x + 1, y, z + 1],
-              [x + 1, y + 1, z + 1],
-              [x + 1, y + 1, z],
-            ],
-            x + 1,
-            y + 0.5,
-            z + 0.5,
-          );
-
-        // Oblique depth always increases with z so the camera looks from
-        // –z.  "front" (normal –z) faces the camera; "back" (normal +z)
-        // always faces away — never visible, skip it.
-        if (sc || !hasVoxel(x, y, z - 1))
-          addObliqueFace(
-            "front",
-            [
-              [x, y, z],
-              [x, y + 1, z],
-              [x + 1, y + 1, z],
-              [x + 1, y, z],
-            ],
-            x + 0.5,
-            y + 0.5,
-            z,
-          );
-      } else {
-        // Perspective Mode uses robust 3D math and backface culling
-        const addPerspFace = (type, vertices, n, c) => {
-          if (sc) {
-            const ox = x + so[0],
-              oy = y + so[1],
-              oz = z + so[2];
-            c = [
-              ox + (c[0] - ox) * sc[0],
-              oy + (c[1] - oy) * sc[1],
-              oz + (c[2] - oz) * sc[2],
-            ];
-          }
-          faces3D.push({
-            type,
-            voxel,
-            vertices: sc
-              ? Heerich._scaleVertices(vertices, x, y, z, sc, so)
-              : vertices,
-            n,
-            c,
-            style: getStyles(type),
-          });
-        };
-
-        if (sc || !hasVoxel(x, y - 1, z))
-          addPerspFace(
-            "top",
-            [
-              [x, y, z],
-              [x + 1, y, z],
-              [x + 1, y, z + 1],
-              [x, y, z + 1],
-            ],
-            [0, -1, 0],
-            [x + 0.5, y, z + 0.5],
-          );
-        if (sc || !hasVoxel(x, y + 1, z))
-          addPerspFace(
-            "bottom",
-            [
-              [x, y + 1, z + 1],
-              [x + 1, y + 1, z + 1],
-              [x + 1, y + 1, z],
-              [x, y + 1, z],
-            ],
-            [0, 1, 0],
-            [x + 0.5, y + 1, z + 0.5],
-          );
-        if (sc || !hasVoxel(x - 1, y, z))
-          addPerspFace(
-            "left",
-            [
-              [x, y, z + 1],
-              [x, y, z],
-              [x, y + 1, z],
-              [x, y + 1, z + 1],
-            ],
-            [-1, 0, 0],
-            [x, y + 0.5, z + 0.5],
-          );
-        if (sc || !hasVoxel(x + 1, y, z))
-          addPerspFace(
-            "right",
-            [
-              [x + 1, y, z],
-              [x + 1, y, z + 1],
-              [x + 1, y + 1, z + 1],
-              [x + 1, y + 1, z],
-            ],
-            [1, 0, 0],
-            [x + 1, y + 0.5, z + 0.5],
-          );
-        if (sc || !hasVoxel(x, y, z - 1))
-          addPerspFace(
-            "front",
-            [
-              [x, y, z],
-              [x, y + 1, z],
-              [x + 1, y + 1, z],
-              [x + 1, y, z],
-            ],
-            [0, 0, -1],
-            [x + 0.5, y + 0.5, z],
-          );
-        if (sc || !hasVoxel(x, y, z + 1))
-          addPerspFace(
-            "back",
-            [
-              [x + 1, y, z + 1],
-              [x + 1, y + 1, z + 1],
-              [x, y + 1, z + 1],
-              [x, y, z + 1],
-            ],
-            [0, 0, 1],
-            [x + 0.5, y + 0.5, z + 1],
-          );
-      }
-
-      // Cache this voxel's 3D faces for incremental updates
       if (faces3D.length > faceStart) {
         this._faceCache3D.set(key, faces3D.slice(faceStart));
       }
     }
 
     this._dirtyKeys.clear();
-    this._faceCacheEpoch = this._epoch;
+    return faces3D;
+  }
 
-    const result = this._projectAndSort(faces3D);
+  /**
+   * Generate faces from stored voxels.
+   *
+   * By default returns projected, depth-sorted 2D faces for SVG rendering.
+   * Pass `{ raw: true }` to get all neighbour-exposed 3D faces without any
+   * camera-dependent culling or projection — the correct input for
+   * `GPURenderer.render()`, which lets the GPU handle its own backface culling.
+   *
+   * Both modes are epoch-cached: repeated calls with no scene changes are free.
+   *
+   * @param {Object} [options]
+   * @param {boolean} [options.raw=false] - Return raw 3D faces instead of projected 2D faces.
+   * @returns {Face[]}
+   */
+  getFaces(options = {}) {
+    if (options.raw) {
+      if (this._cachedRawEpoch === this._epoch && this._cachedRawFaces) {
+        return this._cachedRawFaces;
+      }
+      const result = this._buildFaces3D().filter((f) => f.type !== "content");
+      this._cachedRawFaces = result;
+      this._cachedRawEpoch = this._epoch;
+      return result;
+    }
+
+    if (this._cachedEpoch === this._epoch && this._cachedFaces) {
+      return this._cachedFaces;
+    }
+    const result = this._projectAndSort(this._buildFaces3D());
     this._cachedFaces = result;
     this._cachedEpoch = this._epoch;
     return result;
@@ -1490,6 +1345,17 @@ export class Heerich {
       }
 
       if (projection === "oblique") {
+        // Camera-direction cull: oblique only sees one horizontal face, one
+        // vertical face, and the front. Back is always hidden.
+        if (
+          face.type === "back" ||
+          (face.type === "top"    && depthOffsetY >= 0) ||
+          (face.type === "bottom" && depthOffsetY <= 0) ||
+          (face.type === "left"   && depthOffsetX >= 0) ||
+          (face.type === "right"  && depthOffsetX <= 0)
+        ) continue;
+
+        face.depth = face.c[2] - face.c[0] * dx_norm - face.c[1] * dy_norm;
         const flat = [];
         for (const v of face.vertices) {
           flat.push(

--- a/src/heerich.js
+++ b/src/heerich.js
@@ -5,6 +5,7 @@ import { boxCoords, sphereCoords, lineCoords, fillCoords } from "./shapes.js";
 
 export { boxCoords, sphereCoords, lineCoords, fillCoords };
 export { SVGRenderer } from "./svg-renderer.js";
+export { GPURenderer } from "./gpu-renderer.js";
 
 /**
  * @typedef {Object} StyleObject

--- a/src/heerich.js
+++ b/src/heerich.js
@@ -4,7 +4,6 @@ import { Points } from "./points.js";
 import { boxCoords, sphereCoords, lineCoords, fillCoords } from "./shapes.js";
 
 export { boxCoords, sphereCoords, lineCoords, fillCoords };
-export { GPURenderer } from "./gpu-renderer.js";
 export { SVGRenderer } from "./svg-renderer.js";
 
 /**
@@ -906,7 +905,12 @@ export class Heerich {
       const faceStart = faces3D.length;
 
       if (voxel.content) {
-        faces3D.push({ type: "content", voxel, content: voxel.content, _pos: [x, y, z] });
+        faces3D.push({
+          type: "content",
+          voxel,
+          content: voxel.content,
+          _pos: [x, y, z],
+        });
         this._faceCache3D.set(key, faces3D.slice(faceStart));
         continue;
       }
@@ -925,7 +929,9 @@ export class Heerich {
       const addFace = (type, vertices, n, cx, cy, cz) => {
         let c = [cx, cy, cz];
         if (sc) {
-          const ox = x + so[0], oy = y + so[1], oz = z + so[2];
+          const ox = x + so[0],
+            oy = y + so[1],
+            oz = z + so[2];
           c = [
             ox + (cx - ox) * sc[0],
             oy + (cy - oy) * sc[1],
@@ -935,7 +941,9 @@ export class Heerich {
         faces3D.push({
           type,
           voxel,
-          vertices: sc ? Heerich._scaleVertices(vertices, x, y, z, sc, so) : vertices,
+          vertices: sc
+            ? Heerich._scaleVertices(vertices, x, y, z, sc, so)
+            : vertices,
           n,
           c,
           style: getStyle(type),
@@ -945,17 +953,89 @@ export class Heerich {
       // Emit all 6 neighbor-exposed faces. Camera-direction filtering is
       // deferred to _projectAndSort (for SVG) or left to the GPU.
       if (sc || !hasVoxel(x, y - 1, z))
-        addFace("top",    [[x,y,z],[x+1,y,z],[x+1,y,z+1],[x,y,z+1]],             [0,-1,0], x+0.5, y,   z+0.5);
+        addFace(
+          "top",
+          [
+            [x, y, z],
+            [x + 1, y, z],
+            [x + 1, y, z + 1],
+            [x, y, z + 1],
+          ],
+          [0, -1, 0],
+          x + 0.5,
+          y,
+          z + 0.5,
+        );
       if (sc || !hasVoxel(x, y + 1, z))
-        addFace("bottom", [[x,y+1,z+1],[x+1,y+1,z+1],[x+1,y+1,z],[x,y+1,z]],   [0,1,0],  x+0.5, y+1, z+0.5);
+        addFace(
+          "bottom",
+          [
+            [x, y + 1, z + 1],
+            [x + 1, y + 1, z + 1],
+            [x + 1, y + 1, z],
+            [x, y + 1, z],
+          ],
+          [0, 1, 0],
+          x + 0.5,
+          y + 1,
+          z + 0.5,
+        );
       if (sc || !hasVoxel(x - 1, y, z))
-        addFace("left",   [[x,y,z+1],[x,y,z],[x,y+1,z],[x,y+1,z+1]],             [-1,0,0], x,   y+0.5, z+0.5);
+        addFace(
+          "left",
+          [
+            [x, y, z + 1],
+            [x, y, z],
+            [x, y + 1, z],
+            [x, y + 1, z + 1],
+          ],
+          [-1, 0, 0],
+          x,
+          y + 0.5,
+          z + 0.5,
+        );
       if (sc || !hasVoxel(x + 1, y, z))
-        addFace("right",  [[x+1,y,z],[x+1,y,z+1],[x+1,y+1,z+1],[x+1,y+1,z]],   [1,0,0],  x+1, y+0.5, z+0.5);
+        addFace(
+          "right",
+          [
+            [x + 1, y, z],
+            [x + 1, y, z + 1],
+            [x + 1, y + 1, z + 1],
+            [x + 1, y + 1, z],
+          ],
+          [1, 0, 0],
+          x + 1,
+          y + 0.5,
+          z + 0.5,
+        );
       if (sc || !hasVoxel(x, y, z - 1))
-        addFace("front",  [[x,y,z],[x,y+1,z],[x+1,y+1,z],[x+1,y,z]],             [0,0,-1], x+0.5, y+0.5, z);
+        addFace(
+          "front",
+          [
+            [x, y, z],
+            [x, y + 1, z],
+            [x + 1, y + 1, z],
+            [x + 1, y, z],
+          ],
+          [0, 0, -1],
+          x + 0.5,
+          y + 0.5,
+          z,
+        );
       if (sc || !hasVoxel(x, y, z + 1))
-        addFace("back",   [[x+1,y,z+1],[x+1,y+1,z+1],[x,y+1,z+1],[x,y,z+1]],   [0,0,1],  x+0.5, y+0.5, z+1);
+        addFace(
+          "back",
+          [
+            [x + 1, y, z + 1],
+            [x + 1, y + 1, z + 1],
+            [x, y + 1, z + 1],
+            [x, y, z + 1],
+          ],
+          [0, 0, 1],
+          x + 0.5,
+          y + 0.5,
+          z + 1,
+        );
 
       if (faces3D.length > faceStart) {
         this._faceCache3D.set(key, faces3D.slice(faceStart));
@@ -972,7 +1052,7 @@ export class Heerich {
    * By default returns projected, depth-sorted 2D faces for SVG rendering.
    * Pass `{ raw: true }` to get all neighbour-exposed 3D faces without any
    * camera-dependent culling or projection — the correct input for
-   * `GPURenderer.render()`, which lets the GPU handle its own backface culling.
+   * GPURenderer, which lets the GPU handle its own backface culling.
    *
    * Both modes are epoch-cached: repeated calls with no scene changes are free.
    *
@@ -1350,11 +1430,12 @@ export class Heerich {
         // vertical face, and the front. Back is always hidden.
         if (
           face.type === "back" ||
-          (face.type === "top"    && depthOffsetY >= 0) ||
+          (face.type === "top" && depthOffsetY >= 0) ||
           (face.type === "bottom" && depthOffsetY <= 0) ||
-          (face.type === "left"   && depthOffsetX >= 0) ||
-          (face.type === "right"  && depthOffsetX <= 0)
-        ) continue;
+          (face.type === "left" && depthOffsetX >= 0) ||
+          (face.type === "right" && depthOffsetX <= 0)
+        )
+          continue;
 
         face.depth = face.c[2] - face.c[0] * dx_norm - face.c[1] * dy_norm;
         const flat = [];

--- a/src/heerich.js
+++ b/src/heerich.js
@@ -853,23 +853,32 @@ export class Heerich {
 
   /**
    * Build all neighbor-exposed 3D faces for every voxel, using the incremental
-   * per-voxel cache. Always emits all 6 faces (camera direction is irrelevant
-   * here — filtering happens in `_projectAndSort` for SVG, or in the GPU
-   * renderer's own backface culling for 3D output).
+   * per-voxel cache. Emits up to 6 faces per voxel. The `back` face (normal
+   * [0,0,1]) is included so that orthographic/isometric cameras can see it when
+   * rotated past ~90°; oblique always culls it via `cullTypes`.
    *
    * Each face carries `n` (normal) and `c` (center) so that `_projectAndSort`
    * can do backface culling and depth computation without extra lookups.
    *
+   * @param {Set<string>|null} [cullTypes] - Optional set of face type strings to
+   *   skip at generation time (e.g. oblique direction cull). When provided the
+   *   per-voxel incremental cache is bypassed so that the cache always stores
+   *   the full unculled set.
    * @returns {Object[]} Raw 3D face objects
    */
-  _buildFaces3D() {
+  _buildFaces3D(cullTypes = null) {
     const hasVoxel = (x, y, z) => {
       const v = this.voxels.get(this._k(x, y, z));
       return v && v.opaque !== false;
     };
 
     const dirtyKeys = this._dirtyKeys;
-    const useIncremental = dirtyKeys.size > 0 && this._faceCache3D.size > 0;
+    // Bypass the per-voxel cache when direction culling is active: the cache
+    // stores the full unculled set, so mixing culled and unculled entries would
+    // corrupt it. The epoch-level cache in getFaces() still avoids redundant
+    // work for static scenes.
+    const useIncremental =
+      !cullTypes && dirtyKeys.size > 0 && this._faceCache3D.size > 0;
 
     if (useIncremental) {
       for (const dk of dirtyKeys) {
@@ -911,7 +920,7 @@ export class Heerich {
           content: voxel.content,
           _pos: [x, y, z],
         });
-        this._faceCache3D.set(key, faces3D.slice(faceStart));
+        if (!cullTypes) this._faceCache3D.set(key, faces3D.slice(faceStart));
         continue;
       }
 
@@ -927,6 +936,7 @@ export class Heerich {
       const so = voxel.scaleOrigin;
 
       const addFace = (type, vertices, n, cx, cy, cz) => {
+        if (cullTypes && cullTypes.has(type)) return;
         let c = [cx, cy, cz];
         if (sc) {
           const ox = x + so[0],
@@ -950,8 +960,9 @@ export class Heerich {
         });
       };
 
-      // Emit all 6 neighbor-exposed faces. Camera-direction filtering is
-      // deferred to _projectAndSort (for SVG) or left to the GPU.
+      // Emit up to 5 neighbor-exposed faces (back is always omitted — see JSDoc).
+      // Camera-direction filtering for oblique is applied via cullTypes; other
+      // projections filter in _projectAndSort via dot-product backface culling.
       if (sc || !hasVoxel(x, y - 1, z))
         addFace(
           "top",
@@ -1036,8 +1047,7 @@ export class Heerich {
           y + 0.5,
           z + 1,
         );
-
-      if (faces3D.length > faceStart) {
+      if (!cullTypes && faces3D.length > faceStart) {
         this._faceCache3D.set(key, faces3D.slice(faceStart));
       }
     }
@@ -1074,7 +1084,23 @@ export class Heerich {
     if (this._cachedEpoch === this._epoch && this._cachedFaces) {
       return this._cachedFaces;
     }
-    const result = this._projectAndSort(this._buildFaces3D());
+
+    // For oblique projection, cull invisible faces at generation time so the
+    // hot rebuild path never allocates them. Other projections rely on the
+    // dot-product backface check in _projectAndSort and benefit from the
+    // per-voxel incremental cache, so cullTypes stays null for them.
+    let cullTypes = null;
+    if (this.renderOptions.projection === "oblique") {
+      const { depthOffsetX, depthOffsetY } = this.renderOptions;
+      cullTypes = new Set();
+      cullTypes.add("back"); // back face is never visible in oblique
+      if (depthOffsetY >= 0) cullTypes.add("top");
+      if (depthOffsetY <= 0) cullTypes.add("bottom");
+      if (depthOffsetX >= 0) cullTypes.add("left");
+      if (depthOffsetX <= 0) cullTypes.add("right");
+    }
+
+    const result = this._projectAndSort(this._buildFaces3D(cullTypes));
     this._cachedFaces = result;
     this._cachedEpoch = this._epoch;
     return result;
@@ -1339,6 +1365,8 @@ export class Heerich {
 
     const { cameraDistance } = this.renderOptions;
 
+    var calls = 0;
+
     for (const face of faces3D) {
       if (face.type === "content") {
         const [cx, cy, cz] = face._pos;
@@ -1383,6 +1411,9 @@ export class Heerich {
         ];
         if (projection === "oblique") {
           const flat = [];
+          if (calls++ > 100) {
+            debugger;
+          }
           for (const [vx, vy, vz] of corners) {
             flat.push(
               truncate(vx * tileW + vz * depthOffsetX),
@@ -1511,7 +1542,8 @@ export class Heerich {
         b.depth - a.depth ||
         a.voxel.x - b.voxel.x ||
         a.voxel.y - b.voxel.y ||
-        a.voxel.z - b.voxel.z,
+        a.voxel.z - b.voxel.z ||
+        a.type.localeCompare(b.type),
     );
     return projectedFaces;
   }

--- a/src/heerich.js
+++ b/src/heerich.js
@@ -4,6 +4,8 @@ import { Points } from "./points.js";
 import { boxCoords, sphereCoords, lineCoords, fillCoords } from "./shapes.js";
 
 export { boxCoords, sphereCoords, lineCoords, fillCoords };
+export { GPURenderer } from "./gpu-renderer.js";
+export { SVGRenderer } from "./svg-renderer.js";
 
 /**
  * @typedef {Object} StyleObject
@@ -166,16 +168,18 @@ export class Heerich {
     this._cachedEpoch = -1;
     /** @type {Face[]|null} */
     this._cachedFaces = null;
+    /** @type {number} Epoch at which _cachedRawFaces was computed */
+    this._cachedRawEpoch = -1;
+    /** @type {Face[]|null} */
+    this._cachedRawFaces = null;
     /** @type {SVGRenderer|null} */
     this._svgRenderer = null;
     /** @type {boolean} */
     this._batching = false;
-    /** @type {Set<number>} Voxel keys that changed since last getFaces */
+    /** @type {Set<number>} Voxel keys that changed since last _buildFaces3D */
     this._dirtyKeys = new Set();
     /** @type {Map<number, Object[]>} Cached 3D faces per voxel key */
     this._faceCache3D = new Map();
-    /** @type {number} Epoch at which the full cache was last valid */
-    this._faceCacheEpoch = -1;
   }
 
   /**
@@ -232,7 +236,10 @@ export class Heerich {
   /** Mark the scene as modified. */
   _invalidate() {
     this._epoch++;
-    if (!this._batching) this._cachedFaces = null;
+    if (!this._batching) {
+      this._cachedFaces = null;
+      this._cachedRawFaces = null;
+    }
   }
 
   /**
@@ -846,41 +853,25 @@ export class Heerich {
   }
 
   /**
-   * Generate an array of renderable 2D polygon faces from stored voxels, properly depth-sorted.
-   * Results are cached until the scene is modified.
-   * @returns {Face[]}
+   * Build all neighbor-exposed 3D faces for every voxel, using the incremental
+   * per-voxel cache. Always emits all 6 faces (camera direction is irrelevant
+   * here — filtering happens in `_projectAndSort` for SVG, or in the GPU
+   * renderer's own backface culling for 3D output).
+   *
+   * Each face carries `n` (normal) and `c` (center) so that `_projectAndSort`
+   * can do backface culling and depth computation without extra lookups.
+   *
+   * @returns {Object[]} Raw 3D face objects
    */
-  getFaces() {
-    if (this._cachedEpoch === this._epoch && this._cachedFaces) {
-      return this._cachedFaces;
-    }
-
-    const projectedFaces = [];
-    const {
-      projection,
-      tileW,
-      tileH,
-      depthOffsetX,
-      depthOffsetY,
-      cameraX,
-      cameraY,
-      cameraDistance,
-    } = this.renderOptions;
-
+  _buildFaces3D() {
     const hasVoxel = (x, y, z) => {
       const v = this.voxels.get(this._k(x, y, z));
       return v && v.opaque !== false;
     };
 
-    // Oblique depth constants (used in face gen and content projection)
-    const dx_norm = projection === "oblique" ? depthOffsetX / tileW : 0;
-    const dy_norm = projection === "oblique" ? depthOffsetY / tileH : 0;
-
-    // Incremental: only regenerate 3D faces for dirty voxels
     const dirtyKeys = this._dirtyKeys;
     const useIncremental = dirtyKeys.size > 0 && this._faceCache3D.size > 0;
 
-    // Remove cache entries for deleted voxels
     if (useIncremental) {
       for (const dk of dirtyKeys) {
         this._faceCache3D.delete(dk);
@@ -888,8 +879,8 @@ export class Heerich {
     }
 
     const faces3D = [];
+
     for (const [key, voxel] of this.voxels.entries()) {
-      // Reuse cached 3D faces for unchanged voxels
       if (useIncremental && !dirtyKeys.has(key)) {
         const cached = this._faceCache3D.get(key);
         if (cached) {
@@ -900,7 +891,6 @@ export class Heerich {
 
       const { x, y, z, styles } = voxel;
 
-      // Skip fully occluded voxels — all 6 neighbors are opaque
       if (
         !voxel.scale &&
         hasVoxel(x - 1, y, z) &&
@@ -915,231 +905,96 @@ export class Heerich {
 
       const faceStart = faces3D.length;
 
-      // Content voxels: emit a content entry instead of polygon faces
       if (voxel.content) {
-        faces3D.push({
-          type: "content",
-          voxel,
-          content: voxel.content,
-          _pos: [x, y, z],
-        });
+        faces3D.push({ type: "content", voxel, content: voxel.content, _pos: [x, y, z] });
         this._faceCache3D.set(key, faces3D.slice(faceStart));
         continue;
       }
 
-      // Precompute base style (default + styles.default) once per voxel
       const base = styles.default
         ? { ...this.defaultStyle, ...styles.default }
         : this.defaultStyle;
-      const getStyles = (faceName) => {
+      const getStyle = (faceName) => {
         const faceStyle = styles[faceName];
         return faceStyle ? { ...base, ...faceStyle } : base;
       };
 
-      // In Oblique projection:
-      // A standard grid relies on absolute occlusion to decide boundaries.
-      // If we just mapped raw vectors, parallel walls get confused by the math.
-      // We fall back conditionally to explicit voxel checking for oblique, but true vector calculation for perspective.
-
       const sc = voxel.scale;
       const so = voxel.scaleOrigin;
 
-      if (projection === "oblique") {
-        const getDepth = (cx, cy, cz) => cz - cx * dx_norm - cy * dy_norm;
+      const addFace = (type, vertices, n, cx, cy, cz) => {
+        let c = [cx, cy, cz];
+        if (sc) {
+          const ox = x + so[0], oy = y + so[1], oz = z + so[2];
+          c = [
+            ox + (cx - ox) * sc[0],
+            oy + (cy - oy) * sc[1],
+            oz + (cz - oz) * sc[2],
+          ];
+        }
+        faces3D.push({
+          type,
+          voxel,
+          vertices: sc ? Heerich._scaleVertices(vertices, x, y, z, sc, so) : vertices,
+          n,
+          c,
+          style: getStyle(type),
+        });
+      };
 
-        const addObliqueFace = (type, vertices, cx, cy, cz) => {
-          faces3D.push({
-            type,
-            voxel,
-            vertices: sc
-              ? Heerich._scaleVertices(vertices, x, y, z, sc, so)
-              : vertices,
-            depth: getDepth(cx, cy, cz),
-            style: getStyles(type),
-          });
-        };
+      // Emit all 6 neighbor-exposed faces. Camera-direction filtering is
+      // deferred to _projectAndSort (for SVG) or left to the GPU.
+      if (sc || !hasVoxel(x, y - 1, z))
+        addFace("top",    [[x,y,z],[x+1,y,z],[x+1,y,z+1],[x,y,z+1]],             [0,-1,0], x+0.5, y,   z+0.5);
+      if (sc || !hasVoxel(x, y + 1, z))
+        addFace("bottom", [[x,y+1,z+1],[x+1,y+1,z+1],[x+1,y+1,z],[x,y+1,z]],   [0,1,0],  x+0.5, y+1, z+0.5);
+      if (sc || !hasVoxel(x - 1, y, z))
+        addFace("left",   [[x,y,z+1],[x,y,z],[x,y+1,z],[x,y+1,z+1]],             [-1,0,0], x,   y+0.5, z+0.5);
+      if (sc || !hasVoxel(x + 1, y, z))
+        addFace("right",  [[x+1,y,z],[x+1,y,z+1],[x+1,y+1,z+1],[x+1,y+1,z]],   [1,0,0],  x+1, y+0.5, z+0.5);
+      if (sc || !hasVoxel(x, y, z - 1))
+        addFace("front",  [[x,y,z],[x,y+1,z],[x+1,y+1,z],[x+1,y,z]],             [0,0,-1], x+0.5, y+0.5, z);
+      if (sc || !hasVoxel(x, y, z + 1))
+        addFace("back",   [[x+1,y,z+1],[x+1,y+1,z+1],[x,y+1,z+1],[x,y,z+1]],   [0,0,1],  x+0.5, y+0.5, z+1);
 
-        // For oblique, we strictly cull invisible orientations
-        // Scaled voxels bypass neighbor occlusion (they don't fill the cell)
-        if (depthOffsetY < 0 && (sc || !hasVoxel(x, y - 1, z)))
-          addObliqueFace(
-            "top",
-            [
-              [x, y, z],
-              [x + 1, y, z],
-              [x + 1, y, z + 1],
-              [x, y, z + 1],
-            ],
-            x + 0.5,
-            y,
-            z + 0.5,
-          );
-        if (depthOffsetY > 0 && (sc || !hasVoxel(x, y + 1, z)))
-          addObliqueFace(
-            "bottom",
-            [
-              [x, y + 1, z + 1],
-              [x + 1, y + 1, z + 1],
-              [x + 1, y + 1, z],
-              [x, y + 1, z],
-            ],
-            x + 0.5,
-            y + 1,
-            z + 0.5,
-          );
-
-        if (depthOffsetX < 0 && (sc || !hasVoxel(x - 1, y, z)))
-          addObliqueFace(
-            "left",
-            [
-              [x, y, z + 1],
-              [x, y, z],
-              [x, y + 1, z],
-              [x, y + 1, z + 1],
-            ],
-            x,
-            y + 0.5,
-            z + 0.5,
-          );
-        if (depthOffsetX > 0 && (sc || !hasVoxel(x + 1, y, z)))
-          addObliqueFace(
-            "right",
-            [
-              [x + 1, y, z],
-              [x + 1, y, z + 1],
-              [x + 1, y + 1, z + 1],
-              [x + 1, y + 1, z],
-            ],
-            x + 1,
-            y + 0.5,
-            z + 0.5,
-          );
-
-        // Oblique depth always increases with z so the camera looks from
-        // –z.  "front" (normal –z) faces the camera; "back" (normal +z)
-        // always faces away — never visible, skip it.
-        if (sc || !hasVoxel(x, y, z - 1))
-          addObliqueFace(
-            "front",
-            [
-              [x, y, z],
-              [x, y + 1, z],
-              [x + 1, y + 1, z],
-              [x + 1, y, z],
-            ],
-            x + 0.5,
-            y + 0.5,
-            z,
-          );
-      } else {
-        // Perspective Mode uses robust 3D math and backface culling
-        const addPerspFace = (type, vertices, n, c) => {
-          if (sc) {
-            const ox = x + so[0],
-              oy = y + so[1],
-              oz = z + so[2];
-            c = [
-              ox + (c[0] - ox) * sc[0],
-              oy + (c[1] - oy) * sc[1],
-              oz + (c[2] - oz) * sc[2],
-            ];
-          }
-          faces3D.push({
-            type,
-            voxel,
-            vertices: sc
-              ? Heerich._scaleVertices(vertices, x, y, z, sc, so)
-              : vertices,
-            n,
-            c,
-            style: getStyles(type),
-          });
-        };
-
-        if (sc || !hasVoxel(x, y - 1, z))
-          addPerspFace(
-            "top",
-            [
-              [x, y, z],
-              [x + 1, y, z],
-              [x + 1, y, z + 1],
-              [x, y, z + 1],
-            ],
-            [0, -1, 0],
-            [x + 0.5, y, z + 0.5],
-          );
-        if (sc || !hasVoxel(x, y + 1, z))
-          addPerspFace(
-            "bottom",
-            [
-              [x, y + 1, z + 1],
-              [x + 1, y + 1, z + 1],
-              [x + 1, y + 1, z],
-              [x, y + 1, z],
-            ],
-            [0, 1, 0],
-            [x + 0.5, y + 1, z + 0.5],
-          );
-        if (sc || !hasVoxel(x - 1, y, z))
-          addPerspFace(
-            "left",
-            [
-              [x, y, z + 1],
-              [x, y, z],
-              [x, y + 1, z],
-              [x, y + 1, z + 1],
-            ],
-            [-1, 0, 0],
-            [x, y + 0.5, z + 0.5],
-          );
-        if (sc || !hasVoxel(x + 1, y, z))
-          addPerspFace(
-            "right",
-            [
-              [x + 1, y, z],
-              [x + 1, y, z + 1],
-              [x + 1, y + 1, z + 1],
-              [x + 1, y + 1, z],
-            ],
-            [1, 0, 0],
-            [x + 1, y + 0.5, z + 0.5],
-          );
-        if (sc || !hasVoxel(x, y, z - 1))
-          addPerspFace(
-            "front",
-            [
-              [x, y, z],
-              [x, y + 1, z],
-              [x + 1, y + 1, z],
-              [x + 1, y, z],
-            ],
-            [0, 0, -1],
-            [x + 0.5, y + 0.5, z],
-          );
-        if (sc || !hasVoxel(x, y, z + 1))
-          addPerspFace(
-            "back",
-            [
-              [x + 1, y, z + 1],
-              [x + 1, y + 1, z + 1],
-              [x, y + 1, z + 1],
-              [x, y, z + 1],
-            ],
-            [0, 0, 1],
-            [x + 0.5, y + 0.5, z + 1],
-          );
-      }
-
-      // Cache this voxel's 3D faces for incremental updates
       if (faces3D.length > faceStart) {
         this._faceCache3D.set(key, faces3D.slice(faceStart));
       }
     }
 
     this._dirtyKeys.clear();
-    this._faceCacheEpoch = this._epoch;
+    return faces3D;
+  }
 
-    const result = this._projectAndSort(faces3D);
+  /**
+   * Generate faces from stored voxels.
+   *
+   * By default returns projected, depth-sorted 2D faces for SVG rendering.
+   * Pass `{ raw: true }` to get all neighbour-exposed 3D faces without any
+   * camera-dependent culling or projection — the correct input for
+   * `GPURenderer.render()`, which lets the GPU handle its own backface culling.
+   *
+   * Both modes are epoch-cached: repeated calls with no scene changes are free.
+   *
+   * @param {Object} [options]
+   * @param {boolean} [options.raw=false] - Return raw 3D faces instead of projected 2D faces.
+   * @returns {Face[]}
+   */
+  getFaces(options = {}) {
+    if (options.raw) {
+      if (this._cachedRawEpoch === this._epoch && this._cachedRawFaces) {
+        return this._cachedRawFaces;
+      }
+      const result = this._buildFaces3D().filter((f) => f.type !== "content");
+      this._cachedRawFaces = result;
+      this._cachedRawEpoch = this._epoch;
+      return result;
+    }
+
+    if (this._cachedEpoch === this._epoch && this._cachedFaces) {
+      return this._cachedFaces;
+    }
+    const result = this._projectAndSort(this._buildFaces3D());
     this._cachedFaces = result;
     this._cachedEpoch = this._epoch;
     return result;
@@ -1491,6 +1346,17 @@ export class Heerich {
       }
 
       if (projection === "oblique") {
+        // Camera-direction cull: oblique only sees one horizontal face, one
+        // vertical face, and the front. Back is always hidden.
+        if (
+          face.type === "back" ||
+          (face.type === "top"    && depthOffsetY >= 0) ||
+          (face.type === "bottom" && depthOffsetY <= 0) ||
+          (face.type === "left"   && depthOffsetX >= 0) ||
+          (face.type === "right"  && depthOffsetX <= 0)
+        ) continue;
+
+        face.depth = face.c[2] - face.c[0] * dx_norm - face.c[1] * dy_norm;
         const flat = [];
         for (const v of face.vertices) {
           flat.push(

--- a/src/heerich.js
+++ b/src/heerich.js
@@ -5,7 +5,6 @@ import { boxCoords, sphereCoords, lineCoords, fillCoords } from "./shapes.js";
 
 export { boxCoords, sphereCoords, lineCoords, fillCoords };
 export { SVGRenderer } from "./svg-renderer.js";
-export { SVGRenderer } from "./svg-renderer.js";
 
 /**
  * @typedef {Object} StyleObject

--- a/src/heerich.js
+++ b/src/heerich.js
@@ -4,7 +4,6 @@ import { Points } from "./points.js";
 import { boxCoords, sphereCoords, lineCoords, fillCoords } from "./shapes.js";
 
 export { boxCoords, sphereCoords, lineCoords, fillCoords };
-export { GPURenderer } from "./gpu-renderer.js";
 export { SVGRenderer } from "./svg-renderer.js";
 
 /**
@@ -905,7 +904,12 @@ export class Heerich {
       const faceStart = faces3D.length;
 
       if (voxel.content) {
-        faces3D.push({ type: "content", voxel, content: voxel.content, _pos: [x, y, z] });
+        faces3D.push({
+          type: "content",
+          voxel,
+          content: voxel.content,
+          _pos: [x, y, z],
+        });
         this._faceCache3D.set(key, faces3D.slice(faceStart));
         continue;
       }
@@ -924,7 +928,9 @@ export class Heerich {
       const addFace = (type, vertices, n, cx, cy, cz) => {
         let c = [cx, cy, cz];
         if (sc) {
-          const ox = x + so[0], oy = y + so[1], oz = z + so[2];
+          const ox = x + so[0],
+            oy = y + so[1],
+            oz = z + so[2];
           c = [
             ox + (cx - ox) * sc[0],
             oy + (cy - oy) * sc[1],
@@ -934,7 +940,9 @@ export class Heerich {
         faces3D.push({
           type,
           voxel,
-          vertices: sc ? Heerich._scaleVertices(vertices, x, y, z, sc, so) : vertices,
+          vertices: sc
+            ? Heerich._scaleVertices(vertices, x, y, z, sc, so)
+            : vertices,
           n,
           c,
           style: getStyle(type),
@@ -944,17 +952,89 @@ export class Heerich {
       // Emit all 6 neighbor-exposed faces. Camera-direction filtering is
       // deferred to _projectAndSort (for SVG) or left to the GPU.
       if (sc || !hasVoxel(x, y - 1, z))
-        addFace("top",    [[x,y,z],[x+1,y,z],[x+1,y,z+1],[x,y,z+1]],             [0,-1,0], x+0.5, y,   z+0.5);
+        addFace(
+          "top",
+          [
+            [x, y, z],
+            [x + 1, y, z],
+            [x + 1, y, z + 1],
+            [x, y, z + 1],
+          ],
+          [0, -1, 0],
+          x + 0.5,
+          y,
+          z + 0.5,
+        );
       if (sc || !hasVoxel(x, y + 1, z))
-        addFace("bottom", [[x,y+1,z+1],[x+1,y+1,z+1],[x+1,y+1,z],[x,y+1,z]],   [0,1,0],  x+0.5, y+1, z+0.5);
+        addFace(
+          "bottom",
+          [
+            [x, y + 1, z + 1],
+            [x + 1, y + 1, z + 1],
+            [x + 1, y + 1, z],
+            [x, y + 1, z],
+          ],
+          [0, 1, 0],
+          x + 0.5,
+          y + 1,
+          z + 0.5,
+        );
       if (sc || !hasVoxel(x - 1, y, z))
-        addFace("left",   [[x,y,z+1],[x,y,z],[x,y+1,z],[x,y+1,z+1]],             [-1,0,0], x,   y+0.5, z+0.5);
+        addFace(
+          "left",
+          [
+            [x, y, z + 1],
+            [x, y, z],
+            [x, y + 1, z],
+            [x, y + 1, z + 1],
+          ],
+          [-1, 0, 0],
+          x,
+          y + 0.5,
+          z + 0.5,
+        );
       if (sc || !hasVoxel(x + 1, y, z))
-        addFace("right",  [[x+1,y,z],[x+1,y,z+1],[x+1,y+1,z+1],[x+1,y+1,z]],   [1,0,0],  x+1, y+0.5, z+0.5);
+        addFace(
+          "right",
+          [
+            [x + 1, y, z],
+            [x + 1, y, z + 1],
+            [x + 1, y + 1, z + 1],
+            [x + 1, y + 1, z],
+          ],
+          [1, 0, 0],
+          x + 1,
+          y + 0.5,
+          z + 0.5,
+        );
       if (sc || !hasVoxel(x, y, z - 1))
-        addFace("front",  [[x,y,z],[x,y+1,z],[x+1,y+1,z],[x+1,y,z]],             [0,0,-1], x+0.5, y+0.5, z);
+        addFace(
+          "front",
+          [
+            [x, y, z],
+            [x, y + 1, z],
+            [x + 1, y + 1, z],
+            [x + 1, y, z],
+          ],
+          [0, 0, -1],
+          x + 0.5,
+          y + 0.5,
+          z,
+        );
       if (sc || !hasVoxel(x, y, z + 1))
-        addFace("back",   [[x+1,y,z+1],[x+1,y+1,z+1],[x,y+1,z+1],[x,y,z+1]],   [0,0,1],  x+0.5, y+0.5, z+1);
+        addFace(
+          "back",
+          [
+            [x + 1, y, z + 1],
+            [x + 1, y + 1, z + 1],
+            [x, y + 1, z + 1],
+            [x, y, z + 1],
+          ],
+          [0, 0, 1],
+          x + 0.5,
+          y + 0.5,
+          z + 1,
+        );
 
       if (faces3D.length > faceStart) {
         this._faceCache3D.set(key, faces3D.slice(faceStart));
@@ -971,7 +1051,7 @@ export class Heerich {
    * By default returns projected, depth-sorted 2D faces for SVG rendering.
    * Pass `{ raw: true }` to get all neighbour-exposed 3D faces without any
    * camera-dependent culling or projection — the correct input for
-   * `GPURenderer.render()`, which lets the GPU handle its own backface culling.
+   * GPURenderer, which lets the GPU handle its own backface culling.
    *
    * Both modes are epoch-cached: repeated calls with no scene changes are free.
    *
@@ -1349,11 +1429,12 @@ export class Heerich {
         // vertical face, and the front. Back is always hidden.
         if (
           face.type === "back" ||
-          (face.type === "top"    && depthOffsetY >= 0) ||
+          (face.type === "top" && depthOffsetY >= 0) ||
           (face.type === "bottom" && depthOffsetY <= 0) ||
-          (face.type === "left"   && depthOffsetX >= 0) ||
-          (face.type === "right"  && depthOffsetX <= 0)
-        ) continue;
+          (face.type === "left" && depthOffsetX >= 0) ||
+          (face.type === "right" && depthOffsetX <= 0)
+        )
+          continue;
 
         face.depth = face.c[2] - face.c[0] * dx_norm - face.c[1] * dy_norm;
         const flat = [];

--- a/tests/benches.js
+++ b/tests/benches.js
@@ -2,8 +2,10 @@
 // Run: node tests/benches.js
 
 import { run as runGetFaces } from "./getFaces.bench.js";
+import { run as runGetRawFaces } from "./getRawFaces.bench.js";
 import { run as runToSVG } from "./toSVG.bench.js";
 import { run as runIncremental } from "./incremental.bench.js";
+import { run as runGPURenderer } from "./gpuRenderer.bench.js";
 
 const ms = (n) => `${n.toFixed(2)} ms`;
 
@@ -43,9 +45,31 @@ const t0 = performance.now();
 console.log(`# Heerich benchmark report\n`);
 console.log(`_${startedAt}  ·  node ${process.version}  ·  ${process.platform} ${process.arch}_\n`);
 
+function reportGetRawFaces({ rows }) {
+  let out = `\n## getFaces({ raw: true })\n\nDense filled cube, cold = \`_invalidate()\` between calls, warm = cache hit. No projection or camera culling.\n\n`;
+  out += `| Scene | cold | warm |\n`;
+  out += `|---|---|---|\n`;
+  for (const r of rows) {
+    out += `| ${r.size}³ (${r.voxels.toLocaleString()}) | ${ms(r.cold)} | ${ms(r.warm)} |\n`;
+  }
+  return out;
+}
+
+function reportGPURenderer({ rows }) {
+  let out = `\n## GPURenderer.render()\n\nTyped-array packing from pre-built raw faces. \`plain\` = positions+normals+uvs+indices, \`+color\` = with CSS colour parsing, \`yUp\` = with Y/Z axis flip.\n\n`;
+  out += `| Scene | faces | plain | +color | yUp |\n`;
+  out += `|---|---|---|---|---|\n`;
+  for (const r of rows) {
+    out += `| ${r.size}³ (${r.voxels.toLocaleString()}) | ${r.faceCount.toLocaleString()} | ${ms(r.plain)} | ${ms(r.withColor)} | ${ms(r.yUp)} |\n`;
+  }
+  return out;
+}
+
 process.stdout.write(reportGetFaces(runGetFaces()));
+process.stdout.write(reportGetRawFaces(runGetRawFaces()));
 process.stdout.write(reportToSVG(runToSVG()));
 process.stdout.write(reportIncremental(runIncremental()));
+process.stdout.write(reportGPURenderer(runGPURenderer()));
 
 const elapsed = ((performance.now() - t0) / 1000).toFixed(1);
 console.log(`\n_total: ${elapsed}s_`);

--- a/tests/getRawFaces.bench.js
+++ b/tests/getRawFaces.bench.js
@@ -1,0 +1,66 @@
+// Benchmark getFaces({ raw: true }) across scene sizes.
+// Raw mode skips camera culling and projection — the fast path for GPU pipelines.
+// Run directly: node tests/getRawFaces.bench.js
+
+import { Heerich } from "../src/heerich.js";
+
+const SIZES = [10, 25, 40];
+const WARMUP = 5;
+const ITERS = 30;
+
+function buildScene(size) {
+  const h = new Heerich();
+  h.batch(() => {
+    h.applyGeometry({
+      type: "box",
+      position: [0, 0, 0],
+      size: [size, size, size],
+    });
+  });
+  return h;
+}
+
+function bench(fn) {
+  for (let i = 0; i < WARMUP; i++) fn();
+  const samples = [];
+  for (let i = 0; i < ITERS; i++) {
+    const t = performance.now();
+    fn();
+    samples.push(performance.now() - t);
+  }
+  samples.sort((a, b) => a - b);
+  return {
+    median: samples[Math.floor(samples.length / 2)],
+    min: samples[0],
+    mean: samples.reduce((a, b) => a + b, 0) / samples.length,
+  };
+}
+
+export function run() {
+  const rows = [];
+  for (const size of SIZES) {
+    const h = buildScene(size);
+    const cold = bench(() => {
+      h._invalidate();
+      h.getFaces({ raw: true });
+    });
+    const warm = bench(() => h.getFaces({ raw: true }));
+    rows.push({
+      size,
+      voxels: size ** 3,
+      cold: cold.median,
+      warm: warm.median,
+    });
+  }
+  return { name: "getRawFaces", rows, meta: { warmup: WARMUP, iters: ITERS } };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const { rows, meta } = run();
+  console.log(`node ${process.version}   warmup=${meta.warmup} iters=${meta.iters}\n`);
+  for (const r of rows) {
+    console.log(
+      `  ${r.size}³ (${r.voxels.toLocaleString().padStart(9)})  cold=${r.cold.toFixed(2).padStart(7)} ms  warm=${r.warm.toFixed(2).padStart(7)} ms`,
+    );
+  }
+}

--- a/tests/gpuRenderer.bench.js
+++ b/tests/gpuRenderer.bench.js
@@ -1,0 +1,70 @@
+// Benchmark GPURenderer.render() — typed-array packing from raw faces.
+// Measures just the GPURenderer step, not face generation (that's getRawFaces.bench.js).
+// Run directly: node tests/gpuRenderer.bench.js
+
+import { Heerich } from "../src/heerich.js";
+import { GPURenderer } from "../src/gpu-renderer.js";
+
+const SIZES = [10, 25, 40];
+const WARMUP = 5;
+const ITERS = 30;
+
+function buildRawFaces(size) {
+  const h = new Heerich();
+  h.batch(() => {
+    h.applyGeometry({
+      type: "box",
+      position: [0, 0, 0],
+      size: [size, size, size],
+    });
+  });
+  return h.getFaces({ raw: true });
+}
+
+function bench(fn) {
+  for (let i = 0; i < WARMUP; i++) fn();
+  const samples = [];
+  for (let i = 0; i < ITERS; i++) {
+    const t = performance.now();
+    fn();
+    samples.push(performance.now() - t);
+  }
+  samples.sort((a, b) => a - b);
+  return {
+    median: samples[Math.floor(samples.length / 2)],
+    min: samples[0],
+    mean: samples.reduce((a, b) => a + b, 0) / samples.length,
+  };
+}
+
+export function run() {
+  const rows = [];
+  for (const size of SIZES) {
+    const faces = buildRawFaces(size);
+    const renderer = new GPURenderer();
+
+    const plain = bench(() => renderer.render(faces));
+    const withColor = bench(() => renderer.render(faces, { color: true }));
+    const yUp = bench(() => renderer.render(faces, { yUp: true }));
+
+    rows.push({
+      size,
+      voxels: size ** 3,
+      faceCount: renderer.render(faces).faceCount,
+      plain: plain.median,
+      withColor: withColor.median,
+      yUp: yUp.median,
+    });
+  }
+  return { name: "gpuRenderer", rows, meta: { warmup: WARMUP, iters: ITERS } };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const { rows, meta } = run();
+  console.log(`node ${process.version}   warmup=${meta.warmup} iters=${meta.iters}\n`);
+  for (const r of rows) {
+    console.log(
+      `  ${r.size}³ (${r.voxels.toLocaleString().padStart(9)})  ${r.faceCount.toLocaleString().padStart(7)} faces  plain=${r.plain.toFixed(2).padStart(7)} ms  +color=${r.withColor.toFixed(2).padStart(7)} ms  yUp=${r.yUp.toFixed(2).padStart(7)} ms`,
+    );
+  }
+}


### PR DESCRIPTION
## Add GPU renderer (GPURenderer)                                                                                                                                                                                               
  
Adds a GPURenderer class that converts Heerich voxel faces into typed arrays ready to upload directly to a WebGL/WebGPU buffer.

## What's new               
### GPURenderer (src/gpu-renderer.js)
- Takes getFaces({ raw: true }) output and packs it into Float32Array/Uint32Array buffers: position, normal, uv, index, and optionally color
   - Can use just getFaces, but Heerich-culled faces will be missing
- Each visible quad is triangulated into two CCW triangles with a winding-order check per face (left/right faces are CW in Heerich's vertex ordering and are flipped automatically)                                          
- options.yUp converts from Heerich's Y-down/Z-into-screen space to Three.js Y-up/Z-toward-viewer by negating Y and Z — determinant +1 (proper rotation), so winding is preserved without any extra flip
- options.scale applies a uniform scale to vertex positions                                                                                                                                                                  
- options.color parses face.style.fill (supports #rgb, #rrggbb, rgb(), rgba()) and packs per-vertex RGB floats                                                                                                               

### Exports                  
- GPURenderer is now exported from the main heerich.js entry point alongside SVGRenderer                                                                                                                                     

### Example & benchmarks                                                                                                                                                                                                         

- site/gpu/ — a Three.js demo using the GPU renderer with post-processing                                                                                                                                                    
- tests/gpuRenderer.bench.js — benchmarks render throughput across 10³/25³/40³ voxel scenes with plain, +color, and yUp variants
- tests/getRawFaces.bench.js — benchmarks the getFaces({ raw: true }) step independently                                                                                                                                     
                           
## Usage                                                                                                                                                                                                                        
```
import { Heerich, GPURenderer } from 'heerich';                                                                                                                                                                              
import * as THREE from 'three';

const engine = new Heerich();                                                                                                                                                                                                
engine.addGeometry({ type: 'box', position: [0,0,0], size: [4,4,4] });

const { position, normal, uv, index } = new GPURenderer().render(                                                                                                                                                            
  engine.getFaces({ raw: true }),
  { yUp: true },                                                                                                                                                                                                             
);                                                                                                                                                                                                                           
  
const geo = new THREE.BufferGeometry();                                                                                                                                                                                      
geo.setAttribute('position', new THREE.BufferAttribute(position, 3));
geo.setAttribute('normal',   new THREE.BufferAttribute(normal,   3));
geo.setAttribute('uv',       new THREE.BufferAttribute(uv,       2));                                                                                                                                                        
geo.setIndex(new THREE.BufferAttribute(index, 1));
scene.add(new THREE.Mesh(geo, new THREE.MeshStandardMaterial()));
```