### PR TITLE
Updating with various world-space <--> screen-space <--> voxel-space query functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,6 +629,77 @@ const redVoxels = h.findVoxels(v => v.styles?.default?.fill === '#ff0000')
 
 Returns a plain array of voxel objects. Each voxel has `x`, `y`, `z`, `styles`, and optionally `meta`, `scale`, `scaleOrigin`, `content`, and `opaque`. The returned references are live — mutations to them affect the scene (call `h.batch(() => {})` or trigger `applyStyle` to rerender after manual mutations).
 
+### `getVoxelInfo(posOrVoxel)`
+
+Returns projected position and size data for a single voxel. Accepts either a `[x, y, z]` coordinate array or a voxel object reference (from `getVoxel()`, `findVoxels()`, or `face.voxel`).
+
+```js
+const info = h.getVoxelInfo([2, 0, 3])
+const info = h.getVoxelInfo(someVoxelRef)
+
+// {
+//   voxel              — the raw voxel object (null if not found)
+//   center3D           — [x+0.5, y+0.5, z+0.5] in voxel space
+//   center2D           — { x, y } projected centroid in pixel space
+//   bounds2D           — { x, y, w, h } pixel bounding box of visible faces
+//   normalizedCenter2D — { x, y } center as 0–1 fraction of scene bounds
+//   normalizedSize2D   — { w, h } size as 0–1 fraction of scene bounds
+// }
+```
+
+All 2D values are in the same coordinate space as `getFaces()` and `getBounds()` — before any SVG viewBox offset or padding. `bounds2D` is `null` when the voxel exists but all its faces are culled (e.g. fully surrounded).
+
+```js
+// Combine with findVoxels to query a group
+const voxels = h.findVoxels(v => v.meta?.id === 'tower')
+const infos = voxels.map(v => h.getVoxelInfo(v))
+const avgX = infos.reduce((s, i) => s + i.center2D.x, 0) / infos.length
+```
+
+### `findByPosition([x, y], options?)`
+
+Finds the frontmost voxel at a 2D screen-space position. Iterates projected faces front-to-back and returns the first hit, or `null` if the position is over empty space.
+
+```js
+const hit = h.findByPosition([px, py])
+// { voxel, face } | null
+//   voxel — the hit voxel object
+//   face  — the specific projected face that was hit (includes face.type, face.style, etc.)
+```
+
+Coordinates are in the same raw pixel space as `getFaces()`. When working from mouse events on a rendered SVG, use the SVG coordinate transform to convert client coordinates:
+
+```js
+svgEl.addEventListener('mousemove', e => {
+  const pt = svgEl.createSVGPoint()
+  pt.x = e.clientX
+  pt.y = e.clientY
+  const { x, y } = pt.matrixTransform(svgEl.getScreenCTM().inverse())
+
+  const hit = h.findByPosition([x, y])
+  if (hit) {
+    console.log(hit.voxel.x, hit.voxel.y, hit.voxel.z)
+    console.log(hit.face.type) // 'top', 'front', 'left', …
+  }
+})
+```
+
+If you have mouse coordinates relative to the SVG element (not the viewport), pass the viewBox origin as an offset:
+
+```js
+const bounds = h.getBounds(padding)
+const hit = h.findByPosition([elX, elY], { offset: [bounds.x, bounds.y] })
+```
+
+Combine with `getVoxelInfo` for the full interactivity loop — hit test, then retrieve projected position:
+
+```js
+const hit = h.findByPosition([x, y])
+if (hit) {
+  const { center2D, bounds2D, normalizedCenter2D } = h.getVoxelInfo(hit.voxel)
+}
+```
+
 ## Serialization
 
 ```js

--- a/README.md
+++ b/README.md
@@ -608,6 +608,27 @@ h.getNeighbors([2, 3, 1])   // { top, bottom, left, right, front, back }
 for (const voxel of h) { /* voxel.x, voxel.y, voxel.z, voxel.styles, ... */ }
 ```
 
+### `findVoxels(predicate)`
+
+Returns all voxels matching a predicate function. The predicate receives each voxel object and should return `true` to include it.
+
+```js
+// Find by meta ID (set at add time via the meta option)
+h.addGeometry({ type: 'box', position: [0, 0, 0], size: 3, meta: { id: 'tower' } })
+const tower = h.findVoxels(v => v.meta?.id === 'tower')
+
+// Find all voxels at ground level
+const ground = h.findVoxels(v => v.y === 0)
+
+// Find voxels in a coordinate range
+const slab = h.findVoxels(v => v.x >= 2 && v.x <= 5 && v.z >= 2 && v.z <= 5)
+
+// Find by style property
+const redVoxels = h.findVoxels(v => v.styles?.default?.fill === '#ff0000')
+```
+
+Returns a plain array of voxel objects. Each voxel has `x`, `y`, `z`, `styles`, and optionally `meta`, `scale`, `scaleOrigin`, `content`, and `opaque`. The returned references are live — mutations to them affect the scene (call `h.batch(() => {})` or trigger `applyStyle` to rerender after manual mutations).
+
 ## Serialization
 
 ```js

--- a/site/index.html
+++ b/site/index.html
@@ -249,6 +249,8 @@
             <li><a href="#opaque">Transparent voxels</a></li>
             <li><a href="#content-voxels">Content voxels</a></li>
             <li><a href="#queries">Querying voxels</a></li>
+            <li><a href="#find-voxels">Finding voxels</a></li>
+            <li><a href="#find-by-position">Position queries</a></li>
             <li><a href="#animation">Animation</a></li>
             <li><a href="#combined">Putting it all together</a></li>
             <li><a href="#gallery">After Heerich</a></li>
@@ -1253,6 +1255,111 @@ for (const voxel of heerich) { ... }
 // Serialization
 const json = heerich.toJSON()
 const copy = Heerich.fromJSON(json)</code></pre>
+        </div>
+      </div>
+
+      <!-- ─── findVoxels ──────────────────────────────────── -->
+
+      <div class="section-row" id="find-voxels">
+        <div class="section-demo">
+          <div class="demo" id="demo-find-voxels">
+            <div class="demo-canvas"></div>
+            <div class="demo-controls">
+              <label class="control-label">
+                Highlight
+                <select class="control-select" data-bind="group">
+                  <option value="all">all groups</option>
+                  <option value="base">base</option>
+                  <option value="tower">tower</option>
+                  <option value="pillar">pillars</option>
+                </select>
+              </label>
+            </div>
+          </div>
+        </div>
+        <div class="section-text">
+          <h2>Finding voxels</h2>
+          <p>
+            <code>findVoxels(predicate)</code> scans the entire voxel map and
+            returns every voxel for which the predicate returns
+            <code>true</code>. The most common pattern is tagging groups at
+            add time with a <code>meta</code> id, then querying by that id
+            later.
+          </p>
+          <pre><code>h.addGeometry({ type: 'box', position: [0, 4, 0], size: [7, 2, 7],
+  meta: { id: 'base' } })
+h.addGeometry({ type: 'box', position: [2, 1, 2], size: [3, 3, 3],
+  meta: { id: 'tower' } })
+
+// Retrieve a named group
+const tower = h.findVoxels(v => v.meta?.id === 'tower')
+
+// Restyle the result
+for (const voxel of tower) {
+  h.applyStyle({
+    type: 'box', position: [voxel.x, voxel.y, voxel.z], size: 1,
+    style: { default: { fill: '#e05252' } }
+  })
+}</code></pre>
+          <p>
+            Predicates can match on any voxel property — coordinates, style
+            values, or arbitrary <code>meta</code> fields. The returned array
+            contains live references to the stored voxel objects.
+          </p>
+          <pre><code>// Find all voxels at ground level
+h.findVoxels(v => v.y === 0)
+
+// Find within a coordinate range
+h.findVoxels(v => v.x >= 2 && v.x <= 5)</code></pre>
+        </div>
+      </div>
+
+      <!-- ─── findByPosition / getVoxelInfo ────────────── -->
+
+      <div class="section-row" id="find-by-position">
+        <div class="section-demo">
+          <div class="demo" id="demo-find-by-pos">
+            <div class="demo-canvas"></div>
+            <div class="demo-controls">
+              <div class="demo-hit-info">
+                <span class="hit-placeholder">hover over the scene</span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="section-text">
+          <h2>Position queries</h2>
+          <p>
+            <code>findByPosition([x, y])</code> performs a 2D screen-space
+            hit test against all projected faces, returning the frontmost
+            voxel and face at that position. Coordinates are in the same
+            pixel space as <code>getFaces()</code> — when working from mouse
+            events on a rendered SVG, use the SVG element's coordinate
+            transform to convert:
+          </p>
+          <pre><code>svgEl.addEventListener('mousemove', e => {
+  const pt = svgEl.createSVGPoint()
+  pt.x = e.clientX; pt.y = e.clientY
+  const { x, y } = pt.matrixTransform(svgEl.getScreenCTM().inverse())
+
+  const hit = h.findByPosition([x, y])
+  if (hit) {
+    console.log(hit.voxel.x, hit.voxel.y, hit.voxel.z)
+    console.log(hit.face.type) // 'top', 'front', 'left', …
+  }
+})</code></pre>
+          <p>
+            <code>getVoxelInfo(posOrVoxel)</code> returns the projected
+            centroid, 2D bounding box, and normalized position for any
+            voxel — given either a coordinate array or a voxel reference
+            directly from <code>findByPosition</code>:
+          </p>
+          <pre><code>const { center2D, bounds2D, normalizedCenter2D } =
+  h.getVoxelInfo(hit.voxel)
+
+// center2D   — { x, y } in pixel space
+// bounds2D   — { x, y, w, h } pixel bounding box of visible faces
+// normalizedCenter2D — { x, y } in 0–1 relative to scene bounds</code></pre>
         </div>
       </div>
 

--- a/site/site.css
+++ b/site/site.css
@@ -827,6 +827,33 @@ input[type="color"]::-webkit-color-swatch {
   margin: 0;
 }
 
+/* ─── Hit info panel (findByPosition demo) ─── */
+.demo-hit-info {
+  font-family: monospace;
+  font-size: 0.8rem;
+  line-height: 1.8;
+  color: var(--text);
+  opacity: 0.8;
+  padding: 0.75rem 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0 1.5rem;
+}
+
+.hit-field {
+  display: inline-flex;
+  gap: 0.4em;
+}
+
+.hit-label {
+  opacity: 0.45;
+}
+
+.hit-placeholder {
+  opacity: 0.35;
+  font-style: italic;
+}
+
 .gallery .demo-canvas {
   aspect-ratio: 1;
 }

--- a/site/site.js
+++ b/site/site.js
@@ -1010,6 +1010,92 @@ setupDemo("demo-queries", (v) => {
   return e.toSVG(getSvgOpts());
 });
 
+// ─── 18. findVoxels ──────────────────
+setupDemo("demo-find-voxels", (v) => {
+  const e = new Heerich({ tile: 22, camera: getCamera(), style: baseStyle });
+
+  e.addGeometry({ type: "box", position: [0, 4, 0], size: [7, 2, 7], meta: { id: "base" } });
+  e.addGeometry({ type: "box", position: [2, 1, 2], size: [3, 3, 3], meta: { id: "tower" } });
+  for (const [px, pz] of [[0, 0], [6, 0], [0, 6], [6, 6]]) {
+    e.addGeometry({ type: "box", position: [px, 2, pz], size: [1, 2, 1], meta: { id: "pillar" } });
+  }
+
+  if (v.group !== "all") {
+    for (const voxel of e.findVoxels((vx) => vx.meta?.id === v.group)) {
+      e.applyStyle({
+        type: "box", position: [voxel.x, voxel.y, voxel.z], size: [1, 1, 1],
+        style: { default: { fill: "#e05252", stroke: "#9b2222" } },
+      });
+    }
+  }
+
+  return e.toSVG(getSvgOpts());
+});
+
+// ─── 19. findByPosition / getVoxelInfo ───────────────
+let _posQueryEngine = null;
+
+setupDemo("demo-find-by-pos", () => {
+  _posQueryEngine = new Heerich({ tile: 24, camera: getCamera(), style: baseStyle });
+  _posQueryEngine.addGeometry({ type: "box", position: [0, 4, 0], size: [7, 2, 7] });
+  _posQueryEngine.addGeometry({ type: "box", position: [1, 2, 1], size: [5, 2, 5] });
+  _posQueryEngine.addGeometry({ type: "box", position: [2, 0, 2], size: [3, 2, 3] });
+  return _posQueryEngine.toSVG(getSvgOpts());
+});
+
+{
+  const demoRoot = document.getElementById("demo-find-by-pos");
+  const canvas = demoRoot.querySelector(".demo-canvas");
+  const infoEl = demoRoot.querySelector(".demo-hit-info");
+
+  canvas.addEventListener("mousemove", (e) => {
+    if (!_posQueryEngine) return;
+    const svg = canvas.querySelector("svg");
+    if (!svg) return;
+
+    const pt = svg.createSVGPoint();
+    pt.x = e.clientX;
+    pt.y = e.clientY;
+    const { x: svgX, y: svgY } = pt.matrixTransform(svg.getScreenCTM().inverse());
+
+    const hit = _posQueryEngine.findByPosition([svgX, svgY]);
+
+    let overlay = svg.querySelector("#heerich-hit-overlay");
+    if (!overlay) {
+      overlay = document.createElementNS("http://www.w3.org/2000/svg", "g");
+      overlay.setAttribute("id", "heerich-hit-overlay");
+      overlay.setAttribute("pointer-events", "none");
+      svg.appendChild(overlay);
+    }
+
+    if (hit) {
+      const { center2D, bounds2D, normalizedCenter2D } = _posQueryEngine.getVoxelInfo(hit.voxel);
+      overlay.innerHTML = bounds2D
+        ? `<rect x="${bounds2D.x}" y="${bounds2D.y}" width="${bounds2D.w}" height="${bounds2D.h}"
+                fill="none" stroke="currentColor" stroke-width="1.5" stroke-dasharray="3 2" opacity="0.6"/>
+           <circle cx="${center2D.x}" cy="${center2D.y}" r="2.5" fill="currentColor" opacity="0.9"/>`
+        : `<circle cx="${center2D.x}" cy="${center2D.y}" r="2.5" fill="currentColor" opacity="0.9"/>`;
+
+      if (infoEl) {
+        const nc = normalizedCenter2D;
+        infoEl.innerHTML =
+          `<span class="hit-field"><span class="hit-label">voxel</span> [${hit.voxel.x}, ${hit.voxel.y}, ${hit.voxel.z}]</span>` +
+          `<span class="hit-field"><span class="hit-label">face</span> ${hit.face.type}</span>` +
+          (nc ? `<span class="hit-field"><span class="hit-label">pos</span> ${(nc.x * 100).toFixed(1)}%, ${(nc.y * 100).toFixed(1)}%</span>` : "");
+      }
+    } else {
+      overlay.innerHTML = "";
+      if (infoEl) infoEl.innerHTML = '<span class="hit-placeholder">hover over the scene</span>';
+    }
+  });
+
+  canvas.addEventListener("mouseleave", () => {
+    const overlay = canvas.querySelector("#heerich-hit-overlay");
+    if (overlay) overlay.innerHTML = "";
+    if (infoEl) infoEl.innerHTML = '<span class="hit-placeholder">hover over the scene</span>';
+  });
+}
+
 // ─── Shared animation utilities ──────
 function easeInOutCubic(t) {
   return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;

--- a/src/heerich.js
+++ b/src/heerich.js
@@ -104,6 +104,31 @@ export { SVGRenderer } from "./svg-renderer.js";
  * @property {number} [_scale] - Perspective scale factor (content faces only)
  */
 
+/**
+ * Test whether a point (px, py) lies inside a convex polygon described by a Points instance.
+ * Uses the cross-product sign method — O(n) on the number of vertices.
+ * @param {number} px
+ * @param {number} py
+ * @param {import('./points.js').Points} points
+ * @returns {boolean}
+ */
+function _pointInConvexPoly(px, py, points) {
+  const d = points.data;
+  const n = d.length >> 1;
+  let sign = 0;
+  for (let i = 0; i < n; i++) {
+    const j = (i + 1) % n;
+    const ex = d[j * 2] - d[i * 2];
+    const ey = d[j * 2 + 1] - d[i * 2 + 1];
+    const cross = ex * (py - d[i * 2 + 1]) - ey * (px - d[i * 2]);
+    if (cross === 0) continue;
+    const s = cross > 0 ? 1 : -1;
+    if (sign === 0) sign = s;
+    else if (sign !== s) return false;
+  }
+  return sign !== 0;
+}
+
 /** Neighbor offsets: [dx, dy, dz, exposedFace] */
 /** @type {[number, number, number, string][]} */
 const ADJ = [
@@ -1689,6 +1714,42 @@ export class Heerich {
       : null;
 
     return { voxel, center3D, center2D, bounds2D, normalizedCenter2D, normalizedSize2D };
+  }
+
+  /**
+   * Find the frontmost voxel at a 2D screen-space position.
+   *
+   * Coordinates are expected in the same raw pixel space that `getFaces()` and
+   * `getBounds()` use — i.e. before any SVG viewBox offset or padding. If you
+   * are working from a mouse event on a rendered SVG, pass the viewBox origin
+   * via `options.offset` to convert automatically:
+   *
+   * ```js
+   * const bounds = h.getBounds(padding)
+   * const hit = h.findByPosition([svgX, svgY], { offset: [bounds.x, bounds.y] })
+   * ```
+   *
+   * @param {[number, number]} pos - 2D position [x, y] in screen/SVG space
+   * @param {Object} [options]
+   * @param {[number, number]} [options.offset] - [dx, dy] added to pos before testing (e.g. viewBox origin from getBounds())
+   * @returns {{ voxel: Voxel, face: Face } | null}
+   */
+  findByPosition(pos, options = {}) {
+    const offset = options.offset;
+    const px = offset ? pos[0] + offset[0] : pos[0];
+    const py = offset ? pos[1] + offset[1] : pos[1];
+
+    const faces = this.getFaces();
+    // Faces are sorted back-to-front for rendering; iterate in reverse to hit
+    // frontmost faces first and return on the first match.
+    for (let i = faces.length - 1; i >= 0; i--) {
+      const face = faces[i];
+      if (face.type === 'content') continue;
+      if (_pointInConvexPoly(px, py, face.points)) {
+        return { voxel: face.voxel, face };
+      }
+    }
+    return null;
   }
 
   /**

--- a/src/heerich.js
+++ b/src/heerich.js
@@ -1369,7 +1369,7 @@ export class Heerich {
    * @returns {{x: number, y: number}}
    */
   _projectPoint(x, y, z) {
-    const { projection, tileW, tileH, tileZ, depthOffsetX, depthOffsetY, cameraX, cameraY, cameraDistance } = this.renderOptions;
+    const { projection, tileW, tileH, depthOffsetX, depthOffsetY, cameraX, cameraY, cameraDistance } = this.renderOptions;
     const t = (v) => Math.round(v * 1e4) / 1e4;
 
     if (projection === 'oblique') {
@@ -1620,6 +1620,75 @@ export class Heerich {
       h: b.h + padding * 2,
       faces,
     };
+  }
+
+  /**
+   * Query position and size data for a single voxel.
+   *
+   * Accepts either a `[x, y, z]` coordinate array or a voxel object reference
+   * (e.g. one returned by `getVoxel()`, `findVoxels()`, or `face.voxel`).
+   *
+   * All 2D values are in the same pixel space as `getFaces()` / `getBounds()` —
+   * i.e. before any SVG viewBox offset or padding is applied.
+   *
+   * @param {[number,number,number]|Voxel} posOrVoxel - Coordinate array or voxel reference
+   * @returns {{
+   *   voxel: Voxel|null,
+   *   center3D: [number,number,number],
+   *   center2D: {x:number, y:number},
+   *   bounds2D: {x:number, y:number, w:number, h:number}|null,
+   *   normalizedCenter2D: {x:number, y:number}|null,
+   *   normalizedSize2D: {w:number, h:number}|null,
+   * }}
+   */
+  getVoxelInfo(posOrVoxel) {
+    const voxel = Array.isArray(posOrVoxel)
+      ? this.getVoxel(posOrVoxel)
+      : posOrVoxel;
+
+    if (!voxel) {
+      return { voxel: null, center3D: null, center2D: null, bounds2D: null, normalizedCenter2D: null, normalizedSize2D: null };
+    }
+
+    const { x, y, z } = voxel;
+    const cx = x + 0.5, cy = y + 0.5, cz = z + 0.5;
+
+    const center3D = /** @type {[number,number,number]} */ ([cx, cy, cz]);
+    const center2D = this._projectPoint(cx, cy, cz);
+
+    // Collect projected bounds from all visible faces belonging to this voxel.
+    // getFaces() is epoch-cached so this filter is the only cost.
+    const faces = this.getFaces();
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    let hasFaces = false;
+    for (let i = 0; i < faces.length; i++) {
+      const face = faces[i];
+      if (face.voxel !== voxel) continue;
+      const d = face.points.data;
+      for (let j = 0; j < d.length; j += 2) {
+        const px = d[j], py = d[j + 1];
+        if (px < minX) minX = px;
+        if (py < minY) minY = py;
+        if (px > maxX) maxX = px;
+        if (py > maxY) maxY = py;
+      }
+      hasFaces = true;
+    }
+
+    const bounds2D = hasFaces
+      ? { x: minX, y: minY, w: maxX - minX, h: maxY - minY }
+      : null;
+
+    // Normalize against scene bounds. getBounds() reuses the same getFaces() cache.
+    const scene = computeBounds(faces);
+    const normalizedCenter2D = scene.w > 0 && scene.h > 0
+      ? { x: (center2D.x - scene.x) / scene.w, y: (center2D.y - scene.y) / scene.h }
+      : null;
+    const normalizedSize2D = bounds2D && scene.w > 0 && scene.h > 0
+      ? { w: bounds2D.w / scene.w, h: bounds2D.h / scene.h }
+      : null;
+
+    return { voxel, center3D, center2D, bounds2D, normalizedCenter2D, normalizedSize2D };
   }
 
   /**

--- a/src/heerich.js
+++ b/src/heerich.js
@@ -1362,6 +1362,44 @@ export class Heerich {
   }
 
   /**
+   * Project a single 3D point to 2D pixel space using the current camera.
+   * @param {number} x
+   * @param {number} y
+   * @param {number} z
+   * @returns {{x: number, y: number}}
+   */
+  _projectPoint(x, y, z) {
+    const { projection, tileW, tileH, tileZ, depthOffsetX, depthOffsetY, cameraX, cameraY, cameraDistance } = this.renderOptions;
+    const t = (v) => Math.round(v * 1e4) / 1e4;
+
+    if (projection === 'oblique') {
+      return {
+        x: t(x * tileW + z * depthOffsetX),
+        y: t(y * tileH + z * depthOffsetY),
+      };
+    }
+
+    if (projection === 'orthographic' || projection === 'isometric') {
+      const { angle = 0, pitch = 0 } = this.renderOptions;
+      const cosT = Math.cos(angle), sinT = Math.sin(angle);
+      const cosP = Math.cos(pitch), sinP = Math.sin(pitch);
+      const x1 = x * cosT - z * sinT;
+      const y1 = y * cosP - (x * sinT + z * cosT) * sinP;
+      return {
+        x: t((x1 + 5) * tileW),
+        y: t((y1 + 5) * tileH),
+      };
+    }
+
+    // perspective
+    const pt = cameraDistance / (z + cameraDistance);
+    return {
+      x: t((cameraX + (x - cameraX) * pt) * tileW),
+      y: t((cameraY + (y - cameraY) * pt) * tileH),
+    };
+  }
+
+  /**
    * Project 3D faces to 2D and sort by depth (shared by getFaces and renderTest).
    * @param {Object[]} faces3D - Face objects with `vertices` (3D) or `points` (already 2D)
    * @returns {Face[]} Projected, depth-sorted face array

--- a/src/heerich.js
+++ b/src/heerich.js
@@ -583,6 +583,24 @@ export class Heerich {
   }
 
   /**
+   * Find all voxels matching a predicate.
+   * @param {function(Voxel): boolean} predicate
+   * @returns {Voxel[]}
+   * @example
+   * // Find by meta ID
+   * engine.findVoxels(v => v.meta?.id === 'tower')
+   * // Find all voxels at a specific Y level
+   * engine.findVoxels(v => v.y === 0)
+   */
+  findVoxels(predicate) {
+    const results = [];
+    for (const voxel of this.voxels.values()) {
+      if (predicate(voxel)) results.push(voxel);
+    }
+    return results;
+  }
+
+  /**
    * Iterate over all voxels. Supports `for (const voxel of heerich)`.
    * @returns {Iterator<Object>}
    */


### PR DESCRIPTION
1. Adds findVoxels function that takes a preciate funciton to query the full voxel list, works with positions, meta etc.
2. Adds a point projection helper that takes a point in voxel space and projects it to screenspace
3. Adds a getVoxelInfo function that returns various useful, calculated metrics for a voxel based either on a 3D voxel position, or a voxel reference. This is a convenience function and is expensive, so should only be used as a query function, rather than as a primary informational function.
4. Adds a findByPosition function that returns a voxel based on a screen-space position.

Adds demos and documentation.